### PR TITLE
encode the embed code as utf-8

### DIFF
--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -156,5 +156,5 @@ echo $mediaplayer;
     <?php 
     $embed = $savvy->render(UNL_MediaHub_Media_Embed::getById($context->id, UNL_MediaHub_Controller::$current_embed_version));
     ?>
-    <textarea cols="25" rows="6" onclick="this.select(); return false;"><?php echo htmlentities($embed); ?></textarea>
+    <textarea cols="25" rows="6" onclick="this.select(); return false;"><?php echo htmlentities($embed, ENT_COMPAT | ENT_HTML401, "UTF-8"); ?></textarea>
 </div>


### PR DESCRIPTION
The production server is running php 5.3, which has the default encoding set to ISO-8859-1, which causes problems with things like magic quotes.
