### PR TITLE
Add and use a permissions table

### DIFF
--- a/data/add_permissions.sql
+++ b/data/add_permissions.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS `permissions` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1;

--- a/src/UNL/MediaHub/Installer.php
+++ b/src/UNL/MediaHub/Installer.php
@@ -31,6 +31,7 @@ class UNL_MediaHub_Installer
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_play_count.sql'), 'Adding media play count', true);
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_poster.sql'), 'Adding media poster', true);
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_uid.sql'), 'Adding uidcreated and uidupdated to media', true);
+        $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_permissions.sql'), 'Adding permissions table', true);
         
         return $messages;
     }
@@ -48,6 +49,7 @@ class UNL_MediaHub_Installer
         drop table if exists media_has_nselement;
         drop table if exists subscriptions;
         drop table if exists user_has_permission;
+        drop table if exists permissions;
         SET FOREIGN_KEY_CHECKS = 1;
         ';
         

--- a/src/UNL/MediaHub/Models/BasePermission.php
+++ b/src/UNL/MediaHub/Models/BasePermission.php
@@ -4,10 +4,9 @@ abstract class UNL_MediaHub_Models_BasePermission extends Doctrine_Record
 
     public function setTableDefinition()
     {
-        $this->setTableName('feeds');
+        $this->setTableName('permissions');
         $this->hasColumn('id',            'integer',   4,    array('unsigned' => 0, 'primary' => true, 'notnull' => true, 'autoincrement' => true));
         $this->hasColumn('title',         'string',    null, array('primary' => false, 'notnull' => true, 'autoincrement' => false, 'unique' => true));
-        $this->hasColumn('description',   'string',    null, array('primary' => false, 'notnull' => false, 'autoincrement' => false));
     }
   
 }


### PR DESCRIPTION
fixes #182 

This creates a permissions table and changes the permissions model to use it instead of the feeds table.

Permissions will be automatically added as needed via https://github.com/unl/UNL_MediaHub/blob/4.0_template/src/UNL/MediaHub/Permission.php#L24
