### PR TITLE
Fix profile images for users with a `-` in their uid

### DIFF
--- a/www/manager/templates/html/UserList.tpl.php
+++ b/www/manager/templates/html/UserList.tpl.php
@@ -3,7 +3,7 @@
 <ul id="userList">
     <?php foreach ($context->items as $user):?>
         <li>
-            <img class="profile_pic medium" src="http://planetred.unl.edu/pg/icon/unl_<?php echo $user->uid ?>/medium/" />
+            <img class="profile_pic medium" src="http://planetred.unl.edu/pg/icon/unl_<?php echo str_replace('-', '_', $user->uid) ?>/medium/" />
             <?php echo @UNL_Services_Peoplefinder::getFullName($user->uid); ?>
             <span class="uid"><?php echo $user->uid ?></span>
             <?php echo $savvy->render($user, 'DeleteUserForm.tpl.php'); ?>


### PR DESCRIPTION
It looks like planetred coverts uids with a `-` to `_`.  Therefor `s-mfairch4` would be `s_mfairch4`.
