### PR TITLE
Ensure a title is provided for standard permissions

### DIFF
--- a/src/UNL/MediaHub/Permission.php
+++ b/src/UNL/MediaHub/Permission.php
@@ -29,6 +29,26 @@ class UNL_MediaHub_Permission extends UNL_MediaHub_Models_BasePermission
         }
         $permission = new self();
         $data = array('id'=>$id);
+        switch ($id) {
+            case self::USER_CAN_INSERT:
+                $data['title'] = 'User Can Insert';
+                break;
+            case self::USER_CAN_UPDATE:
+                $data['title'] = 'User Can Update';
+                break;
+            case self::USER_CAN_DELETE:
+                $data['title'] = 'User Can Delete';
+                break;
+            case self::USER_CAN_UPLOAD:
+                $data['title'] = 'User Can Upload';
+                break;
+            case self::USER_CAN_ADD_USER:
+                $data['title'] = 'User Can Add User';
+                break;
+            default:
+                return $permission;
+        }
+        
         $permission->fromArray($data);
         $permission->save();
         return $permission;


### PR DESCRIPTION
The getById method for the Permission model should only create
permissions we know about. Otherwise, null will be returned and the
application should create a permission using the standard model methods.
