### PR TITLE
Fix integrity constraint violations

### DIFF
--- a/www/manager/templates/html/Feed/Media/Form.tpl.php
+++ b/www/manager/templates/html/Feed/Media/Form.tpl.php
@@ -214,7 +214,6 @@ $controller->setReplacementData('head', $js);
                             </li>
                             <li style="display:none">
                                 <!-- mrss hidden elements that are handled automatically -->
-                                <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[1][media_id]" type="hidden" value="<?php echo getFieldValue($context, 'media', 'id'); ?>"/>
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[1][element]" type="hidden" value="content" />
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[1][value]" type="hidden" value="<?php echo getFieldValue($context, 'media', 'content'); ?>" />
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[1][attributes]" type="hidden" value="<?php echo getFieldAttributes($context, 'media', 'content'); ?>" />
@@ -249,7 +248,6 @@ $controller->setReplacementData('head', $js);
                             </li>
                             <li style="display:none;">
                                 <!-- mrss hidden elements that are handled automatically -->
-                                <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[6][media_id]" type="hidden" value="<?php echo getFieldValue($context, 'media', 'id'); ?>"/>
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[6][element]" type="hidden" value="thumbnail"/>
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[6][value]" type="hidden" value="<?php echo getFieldValue($context, 'media', 'thumbnail'); ?>" />
                                 <input name="UNL_MediaHub_Feed_Media_NamespacedElements_media[6][attributes]" type="hidden" value="<?php echo getFieldAttributes($context, 'media', 'thumbnail'); ?>" />


### PR DESCRIPTION
Fixes #206

Seemingly random integrity constraint violations were being seen when saving media.  It was not very reproducible.  They key violation was `0-media-content` which fits the primary key for the `media_has_nselement` table.  There already exists a record in the database with that key even though no media record exists with an id of '0'.

I think the issue is that `getFieldValue($context, 'media', 'id');` always returns `null`.  And thus doctrine would try to insert a record with a media_id of zero.  I'm not sure how it sometimes worked but not other times, probably something to do with the doctrine internals.

As you can see with the rest of the inputs, none of them specify a media_id, I'm assuming because doctrine knows how to link the records.  Thus, removing them should solve the problem.
