### PR TITLE
Don't display captions when there are none

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -8,7 +8,7 @@ set_include_path(
     .PATH_SEPARATOR.dirname(__FILE__).'/src'
     .PATH_SEPARATOR.dirname(__FILE__).'/lib/php'
     .PATH_SEPARATOR.dirname(__FILE__).'/vendor/simple-cas/simple-cas/src'
-    .PATH_SEPARATOR.dirname(__FILE__).'/vendor/UNL/unl_cache_lite'
+    //.PATH_SEPARATOR.dirname(__FILE__).'/vendor/UNL/unl_cache_lite'
 );
 
 require_once 'UNL/MediaHub.php';
@@ -33,3 +33,13 @@ $itemElements = array(
 UNL_MediaHub_Feed_Media_NamespacedElements_mediahub::setCustomElements($itemElements);
 
 $cache = new UNL_MediaHub_CacheInterface_Mock();
+
+/*
+// Set a few caching options
+$options = array(
+    'cacheDir' => __dir__ . '/tmp/cache/',
+    'lifeTime' => 60*60*24*1 //cache for 1 days
+);
+// Create a Cache_Lite object
+$cache = new \Savvy_Turbo_CacheInterface_UNLCacheLite($options);
+*/

--- a/src/UNL/MediaHub/AmaraAPI.php
+++ b/src/UNL/MediaHub/AmaraAPI.php
@@ -111,18 +111,55 @@ class UNL_MediaHub_AmaraAPI
      * @param string $format the format for the text track (srt or vtt)
      * @return bool|string
      */
-    public function getTextTrack($media_url, $format = 'srt')
+    public function getTextTrackByMediaURL($media_url, $format = 'srt')
     {
         $media_details = $this->getMediaDetails($media_url);
-        
+
         if (!$media_details) {
             return false;
         }
-        
+
         if ($media_details->meta->total_count == 0) {
             return false;
         }
 
         return $this->get('videos/' . $media_details->objects[0]->id . '/languages/en/subtitles/?format='.$format);
+    }
+
+    /**
+     * @param string $media_id the amara media id
+     * @param string $lang_code the lang code
+     * @param string $format the format for the text track (srt or vtt)
+     * @return bool|string
+     */
+    public function getTextTrackByMediaID($media_id, $lang_code, $format = 'srt')
+    {
+        return $this->get('videos/' . $media_id. '/languages/' . $lang_code . '/subtitles/?format='.$format);
+    }
+
+    /**
+     * @param $media_id
+     * @param string $media_url the full media URL
+     * @param string $format the format for the text track (srt or vtt)
+     * @return bool|string
+     */
+    public function getMediaHubTextTracks($media_id, $media_url, $format = 'srt')
+    {
+        $media_details = $this->getMediaDetails($media_url);
+        $tracks        = array();
+
+        if (!$media_details) {
+            return $tracks;
+        }
+
+        if ($media_details->meta->total_count == 0) {
+            return $tracks;
+        }
+        
+        foreach($media_details->objects[0]->languages as $track) {
+            $tracks[$track->code] = UNL_MediaHub_Controller::$url . 'media/'.$media_id.'/'.$format.'?amara_id='.$media_details->objects[0]->id.'&lang_code='.$track->code;
+        }
+
+        return $tracks;
     }
 }

--- a/src/UNL/MediaHub/CacheInterface/UNLCacheLite.php
+++ b/src/UNL/MediaHub/CacheInterface/UNLCacheLite.php
@@ -4,7 +4,7 @@
  * 
  * @author bbieber
  */
-class UNL_MediaHub_CacheInterface_UNLCacheLite extends Savvy_Turbo_CacheInterface_CacheLite
+class UNL_MediaHub_CacheInterface_UNLCacheLite extends Savvy_Turbo_CacheInterface_UNLCacheLite
 {
     
     public $options = array('lifeTime'=>3600);

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -461,5 +461,16 @@ class UNL_MediaHub_Controller
         $url = str_replace('?&', '?', $url);
         return trim($url, '?;=');
     }
+
+    /**
+     * Get a cacheable version of the media player (we need to inject the controller options for this)
+     * 
+     * @param $media
+     * @return UNL_MediaHub_MediaPlayer
+     */
+    public function getMediaPlayer($media)
+    {
+        return new UNL_MediaHub_MediaPlayer($media, $this->options);
+    }
 }
 

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -210,10 +210,10 @@ class UNL_MediaHub_Controller
                 }
                 break;
             case 'media_srt':
-                $this->output[] = new UNL_MediaHub_Media_VideoTextTrack($this->options['id'], 'srt');
+                $this->output[] = new UNL_MediaHub_Media_VideoTextTrack($this->options, 'srt');
                 break;
             case 'media_vtt':
-                $this->output[] = new UNL_MediaHub_Media_VideoTextTrack($this->options['id'], 'vtt');
+                $this->output[] = new UNL_MediaHub_Media_VideoTextTrack($this->options, 'vtt');
                 break;
             case 'media_image':
                 $this->output[] = UNL_MediaHub_Media_Image::getById($this->options['id']);

--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -422,5 +422,11 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
 
         return false;
     }
+    
+    public function getTextTracks()
+    {
+        $api = new UNL_MediaHub_AmaraAPI();
+        return $api->getMediaHubTextTracks($this->id, $this->url);
+    }
 }
 

--- a/src/UNL/MediaHub/Media/VideoTextTrack.php
+++ b/src/UNL/MediaHub/Media/VideoTextTrack.php
@@ -15,18 +15,29 @@ class UNL_MediaHub_Media_VideoTextTrack
     
     protected $track = false;
     
-    public function __construct($media_id, $format = 'srt')
+    public function __construct($options, $format = 'srt')
     {
-        if (!$this->media = UNL_MediaHub_Media::getById($media_id)) {
+        if (!isset($options['id'])) {
             throw new Exception('Unknown media', 404);
         }
-        
+
         $this->format = $format;
-        
         $api = new UNL_MediaHub_AmaraAPI();
         
-        if (!$this->track = $api->getTextTrack($this->media->url, $format)) {
-            throw new Exception('No Text track found for this media', 404);
+        if (isset($options['amara_id'],$options['lan_code'])) {
+            //Skip database calls and get the track direct
+            if (!$this->track = $api->getTextTrackByMediaID($options['amara_id'], $options['lan_code'], $format)) {
+                throw new Exception('No Text track found for this media', 404);
+            }
+        } else {
+            //Find the default language (db calls and multiple api calls)
+            if (!$this->media = UNL_MediaHub_Media::getById($options['id'])) {
+                throw new Exception('Unknown media', 404);
+            }
+
+            if (!$this->track = $api->getTextTrackByMediaURL($this->media->url, $format)) {
+                throw new Exception('No Text track found for this media', 404);
+            }
         }
     }
     

--- a/src/UNL/MediaHub/MediaPlayer.php
+++ b/src/UNL/MediaHub/MediaPlayer.php
@@ -1,0 +1,28 @@
+<?php
+class UNL_MediaHub_MediaPlayer implements \Savvy_Turbo_CacheableInterface
+{
+    public $media;
+    
+    protected $options;
+    
+    function __construct(UNL_MediaHub_Media $media, $options)
+    {
+        $this->media   = $media;
+        $this->options = $options;
+    }
+    
+    public function getCacheKey()
+    {
+        return 'media_' . $this->media->id . '_' . $this->media->dateupdated . $this->options['format'];
+    }
+    
+    public function run()
+    {
+        
+    }
+    
+    public function preRun($cached)
+    {
+        
+    }
+}

--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -47,7 +47,7 @@ if ($type == 'video') {
 $controller->setReplacementData('head', $meta);
 
 // Store the mediaplayer code in a variable, so we can re-use it for the embed
-$mediaplayer = $savvy->render($context, 'MediaPlayer.tpl.php');
+$mediaplayer = $savvy->render($controller->getMediaPlayer($context));
 ?>
 
 

--- a/www/templates/html/MediaPlayer.tpl.php
+++ b/www/templates/html/MediaPlayer.tpl.php
@@ -1,19 +1,19 @@
 <?php
-if ($context->isVideo()) {
-    echo $savvy->render($context, 'MediaPlayer/Video.tpl.php');
+if ($context->media->isVideo()) {
+    echo $savvy->render($context->media, 'MediaPlayer/Video.tpl.php');
 } else {
-    echo $savvy->render($context, 'MediaPlayer/Audio.tpl.php');
+    echo $savvy->render($context->media, 'MediaPlayer/Audio.tpl.php');
 }
 ?>
 
 <script type="text/javascript">
     (function () {
         var e = function () {
-            <?php if (isset($context->id) && $context->id) { ?>
+            <?php if (isset($context->media->id) && $context->media->id) { ?>
             WDN.setPluginParam('mediaelement_wdn', 'options', {
                 success: function (m, v) {
                     //Playcount
-                    var w = false, u = '<?php echo $controller->getURL($context) ?>';
+                    var w = false, u = '<?php echo $controller->getURL($context->media) ?>';
                     m.addEventListener('play', function () {
                         if (!w) {
                             WDN.jQuery.post(u, {action: "playcount"});

--- a/www/templates/html/MediaPlayer/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/Video.tpl.php
@@ -25,5 +25,7 @@ if (isset($controller->options['autoplay']) && !$controller->options['autoplay']
 
 ?>
 <video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> src="<?php echo $context->url; ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo $context->getThumbnailURL(); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
-	<track src="<?php echo $context->getVideoTextTrackURL(); ?>" kind="subtitles" srclang="en" />
+    <?php foreach ($context->getTextTracks() as $lang=>$track):?>
+        <track src="<?php echo htmlentities($track) ?>" kind="subtitles" srclang="<?php echo $lang ?>" />
+    <?php endforeach ?>
 </video>

--- a/www/templates/js/Media/Embed/Version2.tpl.php
+++ b/www/templates/js/Media/Embed/Version2.tpl.php
@@ -1,6 +1,6 @@
 <?php
 $data = array();
-$data['markup'] = $savvy->render($context->media, 'MediaPlayer.tpl.php');
+$data['markup'] = $savvy->render($controller->getMediaPlayer($context->media));
 $data['id'] = $context->media->id;
 ?>
 


### PR DESCRIPTION
This PR accomplishes a few things:

1. Don't add a caption track when there isn't one
2. load multiple languages
3. caches the media player

In order to find out if there are captions defined for a video, we have to make a request to amara each time the video is loaded.  That request could in theory cause longer page loads because we are waiting on an external resource.  The solution was either to do some sort of crazy complicated caching of captions, or to cache the `MediaPlayer` resource after the initial request to amara, thus *reducing* subsequent requests.

If you have a better idea of how to handle this, let me know!

