### PR TITLE
Only show videos from unique channels

### DIFF
--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -28,7 +28,7 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
     function getTopMedia()
     {
         $options = array(
-            'limit'   => 30,
+            'limit'   => null,
             'orderby' => 'popular_play_count'
         );
         $top_media = new UNL_MediaHub_MediaList($options);

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -23,7 +23,7 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
     function run()
     {
         $options = array(
-            'limit'   => 6,
+            'limit'   => 30,
             'orderby' => 'popular_play_count'
         );
         $this->top_media = new UNL_MediaHub_MediaList($options);

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -22,12 +22,54 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
 
     function run()
     {
+        
+    }
+    
+    function getTopMedia()
+    {
         $options = array(
             'limit'   => 30,
             'orderby' => 'popular_play_count'
         );
-        $this->top_media = new UNL_MediaHub_MediaList($options);
-        $this->top_media->run();
+        $top_media = new UNL_MediaHub_MediaList($options);
+        $top_media->run();
+        
+        //return $top_media->items;
+        $limit = 6;
+        $found_channels = array();
+        $media_list = array();
+        foreach ($top_media->items as $media) {
+            if (count($media_list) >= $limit) {
+                //Break out of the loop once we have reached 6 videos
+                break;
+            }
+
+            //Get the media's feeds
+            $feeds = $media->getFeeds();
+            $feeds->run();
+            
+            if (0 == count($feeds->items)) {
+                //skip media with no feeds
+                continue;
+            }
+
+            $skip = false;
+            foreach ($feeds->items as $feed) {
+                if (in_array($feed->id, $found_channels)) {
+                    //We already found a video in this feed, skip it.
+                    $skip = true;
+                }
+
+                $found_channels[] = $feed->id;
+            }
+
+            if ($skip) {
+                continue;
+            }
+
+            $media_list[] = $media;
+        }
+
+        return $media_list;
     }
-    
 }

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -1,8 +1,6 @@
 <?php
 class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
 {
-    public $top_media;
-    
     public $options = array();
     
     function __construct($options = array())

--- a/www/templates/html/DefaultHomepage.tpl.php
+++ b/www/templates/html/DefaultHomepage.tpl.php
@@ -41,36 +41,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
             <span class="wdn-subhead">Popular Videos</span>
         </h2>
         <div class="bp2-wdn-grid-set-thirds wdn-grid-clear">
-            <?php 
-            $limit = 6;
-            $found_channels = array();
-            $i = 0;
-            foreach ($context->top_media->items as $media):
-                if ($i >= $limit) {
-                    //Break out of the loop once we have reached 6 videos
-                    break;
-                }
-                
-                //Get the media's feeds
-                $feeds = $media->getFeeds();
-                $feeds->run();
-                
-                $skip = false;
-                foreach ($feeds->items as $feed) {
-                    if (in_array($feed->id, $found_channels)) {
-                        //We already found a video in this feed, skip it.
-                        $skip = true;
-                    }
-                    
-                    $found_channels[] = $feed->id;
-                }
-                
-                if ($skip) {
-                    continue;
-                }
-                
-                $i++;
-            ?>
+            <?php foreach ($context->getTopMedia() as $media): ?>
                 <div class="wdn-col">
                     <?php echo $savvy->render($media, 'Media/teaser.tpl.php'); ?>
                 </div>

--- a/www/templates/html/DefaultHomepage.tpl.php
+++ b/www/templates/html/DefaultHomepage.tpl.php
@@ -41,7 +41,36 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
             <span class="wdn-subhead">Popular Videos</span>
         </h2>
         <div class="bp2-wdn-grid-set-thirds wdn-grid-clear">
-            <?php foreach ($context->top_media->items as $media): ?>
+            <?php 
+            $limit = 6;
+            $found_channels = array();
+            $i = 0;
+            foreach ($context->top_media->items as $media):
+                if ($i >= $limit) {
+                    //Break out of the loop once we have reached 6 videos
+                    break;
+                }
+                
+                //Get the media's feeds
+                $feeds = $media->getFeeds();
+                $feeds->run();
+                
+                $skip = false;
+                foreach ($feeds->items as $feed) {
+                    if (in_array($feed->id, $found_channels)) {
+                        //We already found a video in this feed, skip it.
+                        $skip = true;
+                    }
+                    
+                    $found_channels[] = $feed->id;
+                }
+                
+                if ($skip) {
+                    continue;
+                }
+                
+                $i++;
+            ?>
                 <div class="wdn-col">
                     <?php echo $savvy->render($media, 'Media/teaser.tpl.php'); ?>
                 </div>


### PR DESCRIPTION
This should prevent one channel from taking up the entire popular list.

I couldn't figure out how to do this with doctrine SQL.  Regular SQL would be something like:

```
SELECT DISTINCT m.* FROM (
    SELECT * FROM `media`
ORDER BY `media`.`popular_play_count` DESC
    ) as m
JOIN feed_has_media ON m.id = feed_has_media.media_id
GROUP BY feed_has_media.feed_id
ORDER BY m.`popular_play_count` DESC
```