### PR TITLE
Dont cache media lists

### DIFF
--- a/src/UNL/MediaHub/FeedList.php
+++ b/src/UNL/MediaHub/FeedList.php
@@ -30,7 +30,6 @@ class UNL_MediaHub_FeedList extends UNL_MediaHub_List
     function __construct($options = array())
     {
         parent::__construct($options);
-        $this->run();
     }
     
     public function filterInputOptions()

--- a/src/UNL/MediaHub/FeedList.php
+++ b/src/UNL/MediaHub/FeedList.php
@@ -30,6 +30,7 @@ class UNL_MediaHub_FeedList extends UNL_MediaHub_List
     function __construct($options = array())
     {
         parent::__construct($options);
+        $this->run();
     }
     
     public function filterInputOptions()

--- a/src/UNL/MediaHub/List.php
+++ b/src/UNL/MediaHub/List.php
@@ -4,7 +4,7 @@
  * 
  * @author bbieber
  */
-abstract class UNL_MediaHub_List implements Countable, UNL_MediaHub_CacheableInterface
+abstract class UNL_MediaHub_List implements Countable
 {
     public $options = array(
         'page'               => 0,
@@ -40,6 +40,8 @@ abstract class UNL_MediaHub_List implements Countable, UNL_MediaHub_CacheableInt
      */
     public $tables = 'null';
     
+    public $ran = false;
+    
     /**
      * Construct a list of items.
      * 
@@ -53,18 +55,13 @@ abstract class UNL_MediaHub_List implements Countable, UNL_MediaHub_CacheableInt
         $this->filterInputOptions();
     }
     
-    function getCacheKey()
-    {
-        return serialize($this->options);
-    }
-    
-    function preRun($cached)
-    {
-        
-    }
-    
     function run()
     {
+        if ($this->ran) {
+            //Don't rerun
+            return false;
+        }
+        
         $query = new Doctrine_Query();
         $query->from($this->tables);
         
@@ -87,6 +84,8 @@ abstract class UNL_MediaHub_List implements Countable, UNL_MediaHub_CacheableInt
         $this->last  = $pager->getLastIndice();
 
         $this->pager = $pager;
+        
+        $this->ran = true;
     }
     
     abstract function setOrderBy(Doctrine_Query &$query);

--- a/src/UNL/MediaHub/List.php
+++ b/src/UNL/MediaHub/List.php
@@ -53,6 +53,8 @@ abstract class UNL_MediaHub_List implements Countable
     {
         $this->options = $options + $this->options;
         $this->filterInputOptions();
+        
+        $this->run();
     }
     
     function run()

--- a/src/UNL/MediaHub/MediaList.php
+++ b/src/UNL/MediaHub/MediaList.php
@@ -25,6 +25,7 @@ class UNL_MediaHub_MediaList extends UNL_MediaHub_List
         $this->options = $options + $this->options;
         $this->filterInputOptions();
         $this->setUpFilter();
+        $this->run();
     }
 
     public function setUpFilter()

--- a/tests/UNL/Mediahub/FeedDBTest.php
+++ b/tests/UNL/Mediahub/FeedDBTest.php
@@ -17,10 +17,12 @@ class UNL_MediaHub_FeedDBTest extends UNL_MediaHub_DBTests_DBTestCase
         $feed_a->delete();
 
         //Verify media was removed
+        $media_list->ran = false; //force a re-run
         $media_list->run();
         $this->assertEquals(0, count($media_list->items), 'feed media should be removed');
         
         //Verify users were removed
+        $user_list->ran = false; //force a re-run
         $user_list->run();
         $this->assertEquals(0, count($user_list->items), 'feed users should be removed');
 


### PR DESCRIPTION
Lists are too volatile to cache at the moment.  Permissions can change and items can be deleted.  A better solution can be made, but this is a quick fix.