### PR TITLE
Ensure delivery of correct media URLs

### DIFF
--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -272,6 +272,23 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
     }
 
     /**
+     * Get the media
+     * 
+     * This will also correct broken URLs for local media (such as http -> https)
+     * 
+     * @return bool|string
+     */
+    public function getMediaURL()
+    {
+        if (!$local_file = $this->getLocalFileName()) {
+            return false;
+        }
+
+        return
+            UNL_MediaHub_Controller::getURL() . 'uploads/' . str_replace(UNL_MediaHub_Manager::getUploadDirectory().'/', '', $local_file);
+    }
+
+    /**
      * Get the tags associated with this media file
      * 
      * @return array()

--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -32,7 +32,6 @@ if ($context->privacy !== 'PUBLIC') {
 
 if ($type == 'video') {
     $meta .= '
-    <meta property="og:video" content="'.htmlentities($context->url, ENT_QUOTES).'" />
     <meta property="og:video:height" content="'.$height.'" />
     <meta property="og:video:width" content="'.$width.'" />
     <meta property="og:video" content="'.UNL_MediaHub_Controller::getURL($context).'" />
@@ -207,7 +206,7 @@ $mediaplayer = $savvy->render($controller->getMediaPlayer($context));
 
                     <a class="wdn-button embed mh-hide-bp2"><span class="wdn-icon-plus wdn-icon"></span>Embed</a>
                     <br>
-                    <a href="<?php echo htmlentities($context->url, ENT_QUOTES); ?>" target="_blank" class="wdn-button mh-hide-bp2"><span class="wdn-icon-up-small mh-flip-180 wdn-icon"></span>Download</a>
+                    <a href="<?php echo htmlentities($context->getMediaURL(), ENT_QUOTES); ?>" target="_blank" class="wdn-button mh-hide-bp2"><span class="wdn-icon-up-small mh-flip-180 wdn-icon"></span>Download</a>
 
                 </div>
 

--- a/www/templates/html/Media/File.tpl.php
+++ b/www/templates/html/Media/File.tpl.php
@@ -1,5 +1,5 @@
 <?php
 /* @var $context UNL_MediaHub_Media_File */
-header('Location: '.$context->url);
+header('Location: '.$context->getMediaURL());
 header('Content-Type: '.$context->type);
 exit();

--- a/www/templates/html/MediaPlayer/Audio.tpl.php
+++ b/www/templates/html/MediaPlayer/Audio.tpl.php
@@ -1,1 +1,1 @@
-<audio class="wdn_player" preload="auto" data-url="<?php echo $controller->getURL($context); ?>" data-mediahub-id="<?php echo $context->id ?>" title="<?php echo $context->title; ?>" src="<?php echo $context->url?>"></audio>
+<audio class="wdn_player" preload="auto" data-url="<?php echo $controller->getURL($context); ?>" data-mediahub-id="<?php echo $context->id ?>" title="<?php echo $context->title; ?>" src="<?php echo $context->getMediaURL()?>"></audio>

--- a/www/templates/html/MediaPlayer/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/Video.tpl.php
@@ -29,7 +29,7 @@ if (isset($controller->options['autoplay']) && !$controller->options['autoplay']
 }
 
 ?>
-<video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> <?php echo $preload ?> src="<?php echo $context->url; ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo $context->getThumbnailURL(); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
+<video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> <?php echo $preload ?> src="<?php echo $context->getMediaURL(); ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo $context->getThumbnailURL(); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
     <?php foreach ($context->getTextTracks() as $lang=>$track):?>
         <track src="<?php echo htmlentities($track) ?>" kind="subtitles" srclang="<?php echo $lang ?>" />
     <?php endforeach ?>

--- a/www/templates/json/Media.tpl.php
+++ b/www/templates/json/Media.tpl.php
@@ -1,6 +1,6 @@
 <?php
 $details = array('id'          => $context->id,
-                 'url'         => $context->url,
+                 'url'         => $context->getMediaURL(),
                  'title'       => $context->title,
                  'description' => $context->description,
                  'length'      => $context->length,

--- a/www/templates/xml/Media.tpl.php
+++ b/www/templates/xml/Media.tpl.php
@@ -1,10 +1,10 @@
 <item>
   <title><?php echo htmlspecialchars($context->title); ?></title>
-  <link><?php echo htmlspecialchars($context->url); ?></link>
+  <link><?php echo htmlspecialchars($context->getMediaURL()); ?></link>
   <description><![CDATA[
   <?php echo $context->description; ?>
   ]]></description>
-  <guid><?php echo htmlspecialchars($context->url); ?></guid>
+  <guid><?php echo htmlspecialchars($context->getMediaURL()); ?></guid>
   <pubDate><?php echo date('r', strtotime($context->datecreated)); ?></pubDate>
   <?php
     try {
@@ -24,5 +24,5 @@
         // Error, just skip this for now.
     }
   ?>
-  <enclosure url="<?php echo $context->url; ?>" length="<?php echo $context->length; ?>" type="<?php echo $context->type; ?>" />
+  <enclosure url="<?php echo $context->getMediaURL(); ?>" length="<?php echo $context->length; ?>" type="<?php echo $context->type; ?>" />
 </item>


### PR DESCRIPTION
This should change the URL of local videos to HTTPS on request.

For example, in chrome, requests for insecure content will not be upgraded with a redirect.  This will ensure that the correct URL for media is used.