### PR TITLE
Fix permissions

### DIFF
--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -208,7 +208,7 @@ class UNL_MediaHub_Controller
             case 'media':
                 $media = $this->findRequestedMedia($this->options);
 
-                if (!$media->canView()) {
+                if (!$media->canView(UNL_MediaHub_AuthService::getInstance()->getUser())) {
                     throw new Exception('You do not have permission to view this.', 403);
                 }
                 
@@ -251,7 +251,7 @@ class UNL_MediaHub_Controller
                 
                 $media_embed = UNL_MediaHub_Media_Embed::getById($id, $version, $this->options);
 
-                if (!$media_embed->media->canView()) {
+                if (!$media_embed->media->canView(UNL_MediaHub_AuthService::getInstance()->getUser())) {
                     throw new Exception('You do not have permission to view this.', 403);
                 }
                 

--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -382,7 +382,7 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
     /**
      * @return bool
      */
-    public function canView()
+    public function canView($user)
     {
         $requires_membership = false;
         
@@ -400,8 +400,6 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
             return true;
         }
         
-
-        $user = UNL_MediaHub_AuthService::getInstance()->getUser();
         //At this point a user needs to be logged in.
         if (!$user) {
             return false;
@@ -413,10 +411,8 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
             'filter'=>new UNL_MediaHub_FeedList_Filter_ByUserWithMediaId($user, $this->id)
         ));
 
-        $feeds->run();
-
         //Can view only if they are a member of the at least one of the feeds (specific permissions don't matter).
-        if (empty($feeds->items)) {
+        if (0 == count($feeds->items)) {
             return false;
         }
         

--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -412,7 +412,7 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
         ));
 
         //Can view only if they are a member of the at least one of the feeds (specific permissions don't matter).
-        if (0 == count($feeds->items)) {
+        if (0 === count($feeds->items)) {
             return false;
         }
         

--- a/tests/UNL/Mediahub/MediaDBTest.php
+++ b/tests/UNL/Mediahub/MediaDBTest.php
@@ -20,6 +20,40 @@ class UNL_MediaHub_MediaDBTest extends UNL_MediaHub_DBTests_DBTestCase
     }
 
     /**
+     * Test the canView Logic
+     * 
+     * @test
+     */
+    public function canView()
+    {
+        $this->prepareTestDB();
+
+        //Private video
+        $media_d = UNL_MediaHub_Media::getById(4);
+        
+        //unlisted video
+        $media_e = UNL_MediaHub_Media::getById(3);
+        
+        //public video
+        $media_c = UNL_MediaHub_Media::getById(5);
+
+        $user_a = UNL_MediaHub_User::getByUid('test_a');
+        $user_b = UNL_MediaHub_User::getByUid('test_b');
+
+        //Test a video that is private
+        $this->assertTrue($media_d->canView($user_a));
+        $this->assertFalse($media_d->canView($user_b));
+
+        //Test a video that is unlisted
+        $this->assertTrue($media_e->canView($user_a));
+        $this->assertTrue($media_e->canView($user_b));
+
+        //Test a video that is public
+        $this->assertTrue($media_c->canView($user_a));
+        $this->assertTrue($media_c->canView($user_b));
+    }
+
+    /**
      * Test the delete logic is working and deleted all related entries
      * @test
      */


### PR DESCRIPTION
This fixes a bug where private videos were not always 'private'.

`empty()` was always returning true, causing anyone who is logged in to be able to view any private video.