### PR TITLE
Allow for https embeds

### DIFF
--- a/config.sample.php
+++ b/config.sample.php
@@ -18,7 +18,7 @@ UNL_MediaHub::registerAutoloaders();
 UNL_MediaHub::$dsn = 'mysql://mediahub:mediahub@localhost/mediahub';
 
 UNL_MediaHub_Controller::$url = 'http://localhost:8007/';
-UNL_MediaHub_Controller::$thumbnail_generator = 'http://itunes.unl.edu/thumbnails.php?url=';
+UNL_MediaHub_Controller::$thumbnail_generator = 'https://itunes.unl.edu/thumbnails.php?url=';
 
 UNL_MediaHub_AmaraAPI::$amara_username = false;
 UNL_MediaHub_AmaraAPI::$amara_api_key  = false;

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -450,6 +450,11 @@ class UNL_MediaHub_Controller
 
         return self::addURLParams($url, $params);
     }
+    
+    public static function toAgnosticURL($url)
+    {
+        return str_replace('http://', '//', $url);
+    }
 
     /**
      * Add unique querystring parameters to a URL

--- a/www/templates/html/Media/Embed/Version2.tpl.php
+++ b/www/templates/html/Media/Embed/Version2.tpl.php
@@ -1,4 +1,4 @@
 <div id="mediahub_embed_<?php echo $context->media->id ?>" class="mediahub-embed" data-mediahub-embed-version="2">
     <a href="<?php echo $controller->getURL($context->media)?>"><?php echo $context->media->title ?></a>
 </div>
-<script type="text/javascript" src="<?php echo UNL_MediaHub_Controller::$url?>media/<?php echo $context->media->id  ?>/embed/2?autoplay=0"></script>
+<script type="text/javascript" src="<?php echo UNL_MediaHub_Controller::toAgnosticURL(UNL_MediaHub_Controller::$url)?>media/<?php echo $context->media->id  ?>/embed/2?autoplay=0"></script>

--- a/www/templates/html/MediaPlayer.tpl.php
+++ b/www/templates/html/MediaPlayer.tpl.php
@@ -184,7 +184,7 @@ $getTracks = $context->media->getTextTrackURLs();
                     };
 
                     // Playcount
-                    var w = false, u = '<?php echo $controller->getURL($context->media) ?>';
+                    var w = false, u = '<?php echo UNL_MediaHub_Controller::toAgnosticURL($controller->getURL($context->media)) ?>';
                     m.addEventListener('play', function () {
                         if (!w) {
                             $.post(u, {action: "playcount"});

--- a/www/templates/html/MediaPlayer.tpl.php
+++ b/www/templates/html/MediaPlayer.tpl.php
@@ -214,12 +214,12 @@ $getTracks = $context->media->getTextTrackURLs();
                             var sharelinks = {
                                 "wdn-icon-mail":     {title: 'Email', url:'mailto:?body=Checkout this ' + media_type + ': ' + share_url + '&subject=' + media_type + ' : ' + $title},
                                 "wdn-icon-facebook":     {title: 'Facebook', url:'https://www.facebook.com/sharer/sharer.php?u=' + share_url},  // facebook
-                                "wdn-icon-twitter":     {title: 'Twitter', url:'http://twitter.com/share?text=' + media_type + ': ' + $title + '&url=' + share_url}, // twitter
-                                "wdn-icon-linkedin-squared":     {title: 'LinkedIn', url:'http://www.linkedin.com/shareArticle?mini=true&url=' + share_url + '&title='+ $title +'&summary=Checkout this '+ media_type +'%20&source=University%20of%20Nebraska%20-%20Lincoln%20MediaHub'} //google plus
+                                "wdn-icon-twitter":     {title: 'Twitter', url:'https://twitter.com/share?text=' + media_type + ': ' + $title + '&url=' + share_url}, // twitter
+                                "wdn-icon-linkedin-squared":     {title: 'LinkedIn', url:'https://www.linkedin.com/shareArticle?mini=true&url=' + share_url + '&title='+ $title +'&summary=Checkout this '+ media_type +'%20&source=University%20of%20Nebraska%20-%20Lincoln%20MediaHub'} //google plus
                             }
 
                             //create share links
-                            var links = '<li><a href="http://go.unl.edu/?url=referer" class="wdn-icon-link" rel="nofollow">Get a Go URL</a></li>';
+                            var links = '<li><a href="https://go.unl.edu/?url=referer" class="wdn-icon-link" rel="nofollow">Get a Go URL</a></li>';
                             for (var key in sharelinks) {
                                 links += '<li class="outpost"><a href="'+sharelinks[key].url+'" rel="nofollow" target="_blank" class="'+key+'" title="Share on '+sharelinks[key].title+'">Share on '+sharelinks[key].title+'</a></li>';
                             }
@@ -307,7 +307,7 @@ $getTracks = $context->media->getTextTrackURLs();
                     }
 
                     //Load the CSS
-                    WDN.loadCSS('<?php echo UNL_MediaHub_Controller::$url; ?>templates/html/css/player.css?v=<?php echo UNL_MediaHub_Controller::VERSION ?>', function() {
+                    WDN.loadCSS('<?php echo UNL_MediaHub_Controller::toAgnosticURL(UNL_MediaHub_Controller::$url); ?>templates/html/css/player.css?v=<?php echo UNL_MediaHub_Controller::VERSION ?>', function() {
                         <?php if($context->media->privacy === "PUBLIC"): ?>
                             initSharing(m, v);
                         <?php endif; ?>

--- a/www/templates/html/MediaPlayer/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/Video.tpl.php
@@ -29,7 +29,7 @@ if (isset($controller->options['autoplay']) && !$controller->options['autoplay']
 }
 
 ?>
-<video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> <?php echo $preload ?> src="<?php echo $context->getMediaURL(); ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo $context->getThumbnailURL(); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
+<video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> <?php echo $preload ?> src="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getMediaURL()); ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getThumbnailURL()); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
     <?php foreach ($context->getTextTrackURLs() as $lang=>$track):?>
         <track src="<?php echo htmlentities(UNL_MediaHub_Controller::toAgnosticURL($track)) ?>" kind="subtitles" srclang="<?php echo $lang ?>" />
     <?php endforeach ?>

--- a/www/templates/html/MediaPlayer/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/Video.tpl.php
@@ -31,6 +31,6 @@ if (isset($controller->options['autoplay']) && !$controller->options['autoplay']
 ?>
 <video class="wdn_player" style="width:100%;height:100%" <?php echo $autoplay; ?> <?php echo $preload ?> src="<?php echo $context->getMediaURL(); ?>" controls data-mediahub-id="<?php echo $context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo $context->getThumbnailURL(); ?>" title="<?php echo $context->title; ?>" crossorigin="anonymous">
     <?php foreach ($context->getTextTrackURLs() as $lang=>$track):?>
-        <track src="<?php echo htmlentities($track) ?>" kind="subtitles" srclang="<?php echo $lang ?>" />
+        <track src="<?php echo htmlentities(UNL_MediaHub_Controller::toAgnosticURL($track)) ?>" kind="subtitles" srclang="<?php echo $lang ?>" />
     <?php endforeach ?>
 </video>

--- a/www/templates/html/css/player.css
+++ b/www/templates/html/css/player.css
@@ -540,8 +540,8 @@ a:hover, a:visited {
 }
 @font-face {
     font-family: wdn-icon;
-    src: url(http://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.eot?27007058);
-    src: url(http://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.eot?27007058#iefix) format('embedded-opentype'), url(http://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.woff?27007058) format('woff'), url(http://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.ttf?27007058) format('truetype'), url(http://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.svg?27007058#wdn-icon) format('svg');
+    src: url(https://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.eot?27007058);
+    src: url(https://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.eot?27007058#iefix) format('embedded-opentype'), url(https://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.woff?27007058) format('woff'), url(https://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.ttf?27007058) format('truetype'), url(https://unlcms.unl.edu/wdn/templates_4.0/fonts/fontello/wdn-icon.svg?27007058#wdn-icon) format('svg');
     font-weight: 400;
     font-style: normal
 }


### PR DESCRIPTION
This converts embed code so that it references https wherever possible, and agnostic elsewhere.

A demo of it can be found here [mediahub-test](http://mediahub-test.unl.edu/media/18) and [example embed over https](https://unlcms.unl.edu/university-communications/michael-fairchild/mediahub-embed)