### PR TITLE
Load 4.0 assets for non-framework embeds

### DIFF
--- a/www/templates/js/Media/Embed/Version2.tpl.php
+++ b/www/templates/js/Media/Embed/Version2.tpl.php
@@ -5,31 +5,57 @@ $data['id'] = $context->media->id;
 ?>
 
 (function () {
-    var j, l, t, i, r = function () {
+    var r = function () {
         WDN.loadJQuery(function() {
             var data = <?php echo json_encode($data);?>;
             WDN.jQuery('#mediahub_embed_' + data.id).html(data.markup);
         });
     };
+    
     if (typeof(WDN) === 'undefined') {
-        t = '//www.unl.edu/';
-        l = function () {
-            l = function () {
+        //This isn't the WDN framework, must load a minimum version of it
+        var base_url = '//unlcms.unl.edu/wdn/templates_4.0/scripts/';
+
+        //Scripts that are required to load before running embed code
+        var syncLoad = [
+            "require.js",
+            "modernizr-wdn.js",
+            "ga.js",
+            "wdn.js"
+        ];
+
+        var loadMediaHubJS = function(src) {
+            var script = document.createElement('script'),
+                loaded;
+            script.setAttribute('src', base_url+syncLoad[src]);
+            script.onreadystatechange = script.onload = function() {
+                if (!loaded) {
+                    if (src < syncLoad.length-1) {
+                        loadMediaHubJS(src+1);
+                    } else {
+                        //This is the last script, run requirejs configuration
+                        requirejs.config({
+                            baseUrl: base_url,
+                            map: {
+                                "*": {
+                                    css: 'require-css/css'
+                                }
+                            }
+                        });
+
+                        //We are finally ready; Load embed code
+                        r();
+                    }
+                }
+                loaded = true;
             };
-            WDN.template_path = t;
-            r();
+            document.getElementsByTagName('head')[0].appendChild(script);
         };
-        j = document.createElement('script');
-        j.type = 'text/javascript';
-        j.src = t + 'wdn/templates_3.1/scripts/wdn.js';
-        j.onreadystatechange = function () {
-            if (j.readyState == 'loaded' || j.readyState == 'complete') {
-                l();
-            }
-        };
-        j.onload = l;
-        document.getElementsByTagName("head")[0].appendChild(j);
+
+        //Start loading everything
+        loadMediaHubJS(0);
     } else {
+        //We are in the framework, just run the embed code
         r();
     }
 })();


### PR DESCRIPTION
It was loading 3.1 assets, which meant code was not working as expected, and the player was out of date.