### PR TITLE
Improve thumbnail performance

### DIFF
--- a/src/UNL/MediaHub/AuthService/UNL.php
+++ b/src/UNL/MediaHub/AuthService/UNL.php
@@ -26,10 +26,6 @@ class UNL_MediaHub_AuthService_UNL extends UNL_MediaHub_AuthService_Interface
             $this->logout();
             exit();
         }
-
-        if ($this->isLoggedIn()) {
-            $this->setUser(UNL_MediaHub_User::getByUid(\phpCAS::getUser()));
-        }
     }
 
     /**
@@ -85,5 +81,14 @@ class UNL_MediaHub_AuthService_UNL extends UNL_MediaHub_AuthService_Interface
     public function logout()
     {
         \phpCAS::logoutWithRedirectService(UNL_MediaHub_Controller::$url);
+    }
+    
+    public function getUser()
+    {
+        if (!$this->user && $this->isLoggedIn()) {
+            $this->setUser(UNL_MediaHub_User::getByUid(\phpCAS::getUser()));
+        }
+        
+        return parent::getUser();
     }
 }

--- a/www/index.php
+++ b/www/index.php
@@ -23,7 +23,6 @@ $controller = new UNL_MediaHub_Controller($router->route($_SERVER['REQUEST_URI']
 
 $outputcontroller = new UNL_MediaHub_OutputController();
 $outputcontroller->addGlobal('controller', $controller);
-$outputcontroller->addGlobal('user', UNL_MediaHub_AuthService::getInstance()->getUser());
 $outputcontroller->setTemplatePath(dirname(__FILE__).'/templates/html');
 
 if (isset($cache)) {

--- a/www/templates/html/FeedAndMedia.tpl.php
+++ b/www/templates/html/FeedAndMedia.tpl.php
@@ -4,6 +4,7 @@ $controller->setReplacementData('title', 'UNL | MediaHub | '.htmlspecialchars($c
 $controller->setReplacementData('breadcrumbs', '<ul> <li><a href="http://www.unl.edu/">UNL</a></li> <li><a href="'.UNL_MediaHub_Controller::getURL().'">MediaHub</a></li><li><a href="'.UNL_MediaHub_Controller::getURL().'channels/">All Channels</a></li><li>'.htmlspecialchars($context->feed->title).'</li></ul>');
 $feed_url = htmlentities(UNL_MediaHub_Controller::getURL($context->feed), ENT_QUOTES);
 $baseUrl = UNL_MediaHub_Controller::getURL();
+$user = UNL_MediaHub_AuthService::getInstance()->getUser();
 ?>
 <div class="wdn-band wdn-light-neutral-band mh-feed-info">
     <div class="wdn-inner-wrapper">

--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -11,6 +11,8 @@ if ($context->isVideo()) {
     }
 }
 
+$user = UNL_MediaHub_AuthService::getInstance()->getUser();
+
 $context->loadReference('UNL_MediaHub_Media_Comment');
 $controller->setReplacementData('title', htmlspecialchars($context->title) . ' | MediaHub | University of Nebraska-Lincoln');
 $controller->setReplacementData('breadcrumbs', '<ul> <li><a href="http://www.unl.edu/">UNL</a></li> <li><a href="'.UNL_MediaHub_Controller::getURL().'">MediaHub</a></li> <li><a href="'.UNL_MediaHub_Controller::getURL().'search/">All Media</a></li> <li>'.htmlspecialchars($context->title).'</li></ul>');

--- a/www/templates/html/Media/teaser.tpl.php
+++ b/www/templates/html/Media/teaser.tpl.php
@@ -2,6 +2,8 @@
 /**
  * @var $context UNL_MediaHub_Media
  */
+
+$user = UNL_MediaHub_AuthService::getInstance()->getUser();
 ?>
 <div class="mh-video-thumb wdn-center">
     <a href="<?php echo UNL_MediaHub_Controller::getURL($context) ?>">


### PR DESCRIPTION
Don't request the user object unless we need it. This shaved off ~100ms for every thumbnail request on my slow machine.