### PR TITLE
Trim extra whitespace from file contents

### DIFF
--- a/src/UNL/MediaHub/Muxer.php
+++ b/src/UNL/MediaHub/Muxer.php
@@ -54,7 +54,7 @@ class UNL_MediaHub_Muxer
 
             //Convert the webvtt format to srt (ffmpeg require srt)
             $vtt = new Captioning\Format\WebvttFile();
-            $vtt->loadFromString($file->file_contents);
+            $vtt->loadFromString(trim($file->file_contents));
             $srt = $vtt->convertTo('subrip');
 
             $srt->save($tmp_srt_file);

--- a/tests/data/sample.vtt
+++ b/tests/data/sample.vtt
@@ -7,3 +7,4 @@ Rebecca: This is a sample first line with a speaker
 2
 00:00:10.500 --> 00:00:15.500 line:15% 
 and this is the second line with the same speaker, shown at top
+


### PR DESCRIPTION
This was causing parsing errors when there was two newlines at the end of the file