### PR TITLE
Save media duration in the database

### DIFF
--- a/data/add_media_duration.sql
+++ b/data/add_media_duration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `media` ADD `duration` INT NOT NULL DEFAULT 0 COMMENT 'the duration of the media in milliseconds' AFTER `length`;

--- a/scripts/updateMissingMediaDuration.php
+++ b/scripts/updateMissingMediaDuration.php
@@ -1,0 +1,40 @@
+<?php
+require_once dirname(__FILE__).'/../config.inc.php';
+
+$mediahub = new UNL_MediaHub();
+
+$list = new UNL_MediaHub_MediaList(['limit'=>99999]);
+
+$list->run();
+
+if (!count($list->items)) {
+    echo 'no records found' . PHP_EOL;
+    exit();
+}
+
+foreach ($list->items as $media) {
+    /**
+     * @var \UNL_MediaHub_Media $media
+     */
+    
+    if (!$media->getLocalFileName()) {
+        //Skip non-local media
+        continue;
+    }
+    
+    if (!empty($media->duration)) {
+        //We already have the duration... skip
+        continue;
+    }
+
+    if (!$duration = $media->findDuration()) {
+        //unable to find duration... skip
+        continue;
+    }
+    
+    //Update and save
+    $media->duration = $duration->getTotalMilliseconds();
+    $media->save();
+    
+    echo $media->id . ' updated ' . PHP_EOL;
+}

--- a/src/UNL/MediaHub/Installer.php
+++ b/src/UNL/MediaHub/Installer.php
@@ -35,6 +35,7 @@ class UNL_MediaHub_Installer
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_views.sql'), 'Adding the media views table', true);
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_text_tracks.sql'), 'Adding media text tracks table', true);
         $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/media_text_tracks_dates.sql'), 'Fixing date fields', true);
+        $messages[] = $this->exec_sql(file_get_contents(dirname(__FILE__).'/../../../data/add_media_duration.sql'), 'Add media duration column', true);
         
         return $messages;
     }

--- a/src/UNL/MediaHub/Manager/PostHandler.php
+++ b/src/UNL/MediaHub/Manager/PostHandler.php
@@ -404,6 +404,11 @@ class UNL_MediaHub_Manager_PostHandler
         // Save details
         $media->synchronizeWithArray($this->post);
         
+        if ($duration = $media->findDuration()) {
+            //Save the duration
+            $media->duration = $duration->getTotalMilliseconds();
+        }
+        
         $media->save();
 
         if (!empty($this->post['feed_id'])) {

--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -544,11 +544,15 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
             return false;
         }
         
-        $mediainfo = UNL_MediaHub::getMediaInfo();
-        $details = $mediainfo->getInfo($this->getLocalFileName());
-        $general = $details->getGeneral();
+        try {
+            $mediainfo = UNL_MediaHub::getMediaInfo();
+            $details = $mediainfo->getInfo($this->getLocalFileName());
+            $general = $details->getGeneral();
 
-        return new UNL_MediaHub_DurationHelper((int)$general->get('duration')->getMilliseconds());
+            return new UNL_MediaHub_DurationHelper((int)$general->get('duration')->getMilliseconds());
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/UNL/MediaHub/Models/BaseMedia.php
+++ b/src/UNL/MediaHub/Models/BaseMedia.php
@@ -13,6 +13,7 @@ abstract class UNL_MediaHub_Models_BaseMedia extends Doctrine_Record
         $this->hasColumn('uidupdated',    'string',    null, array('fixed' => false, 'primary' => false, 'notnull' => false, 'autoincrement' => false));
         $this->hasColumn('poster',        'string',    null, array('fixed' => false, 'primary' => false, 'notnull' => false, 'autoincrement' => false));
         $this->hasColumn('length',        'integer',   4,    array('unsigned' => 0, 'primary' => false, 'notnull' => false, 'autoincrement' => false));
+        $this->hasColumn('duration',      'integer',   null, array('unsigned' => 0, 'primary' => false, 'notnull' => true, 'autoincrement' => false, 'default' => 0));
         $this->hasColumn('type',          'string',    null, array('fixed' => false, 'primary' => false, 'notnull' => true, 'autoincrement' => false));
         $this->hasColumn('title',         'string',    null, array('fixed' => false, 'primary' => false, 'notnull' => true, 'autoincrement' => false));
         $this->hasColumn('description',   'string',    null, array('fixed' => false, 'primary' => false, 'notnull' => true, 'autoincrement' => false));


### PR DESCRIPTION
It is currently very hard to gather stats involving video duration.

For example, to answer the question 'how many hours of video were added in the last month', we would have had to create a custom php script to query all media added in the last month, call the `findDuration()` method and compile the stats.

Now all we will have to do is run a simple sql query.