### PR TITLE
Fix 'thumbnails do not scale correctly for wide pixel-width videos'

### DIFF
--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -569,6 +569,49 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
     }
 
     /**
+     * Get the aspect ratio as a string (4:3 or 16:9)
+     * 
+     * This returns false if we were unable to find the ratio
+     * 
+     * @return bool|string 
+     */
+    public function getAspectRatio()
+    {
+        if (!$this->isVideo()) {
+            return false;
+        }
+
+        try {
+            $mediainfo = UNL_MediaHub::getMediaInfo();
+            $details = $mediainfo->getInfo($this->getLocalFileName());
+            
+            if (!$videos = $details->getVideos()) {
+                return false;
+            }
+            
+            if (!isset($videos[0])) {
+                return false;
+            }
+            
+            $ratio = $videos[0]->get('display_aspect_ratio');
+            
+            if (empty($ratio)) {
+                return false;
+            }
+
+            /**
+             * @var \Mhor\MediaInfo\Attribute\Rate $ratio
+             */
+            return $ratio->getTextValue();
+            
+        } catch (\Exception $e) {
+            //Fail silently
+        }
+        
+        return false;
+    }
+
+    /**
      * Pull amara captions for this video
      * 
      * @return bool

--- a/src/UNL/MediaHub/Media/Image.php
+++ b/src/UNL/MediaHub/Media/Image.php
@@ -73,7 +73,15 @@ class UNL_MediaHub_Media_Image
             mkdir($directory, 0777, true);
         }
         
-        exec(UNL_MediaHub::getFfmpegPath() . " -i $url -ss $time -vcodec mjpeg -vframes 1 -f image2 $file -y", $return, $status);
+        //Default to 16:9
+        $scale = '960:540';
+        
+        if ('4:3' == $media->getAspectRatio()) {
+            //if we can find the aspect ratio and it is 4:3, use a 4:3 image ratio
+            $scale = '800:600';
+        }
+        
+        exec(UNL_MediaHub::getFfmpegPath() . " -i $url -ss $time -vcodec mjpeg -vf \"scale=$scale,setsar=1:1\" -vframes 1 -f image2 $file -y", $return, $status);
 
         if ($status == 0 && file_exists($file)) {
             $media->dateupdated = date('Y-m-d H:i:s');


### PR DESCRIPTION
Scale the video to 1:1 and set the dimension of the video correctly

This is to handle an edge case where a video might be uploaded using a non 1:1 pixel aspect ratio, which causes the thumbnail images to be not scaled correctly.

https://en.wikipedia.org/wiki/Pixel_aspect_ratio

This might cause problems with high resolution videos. Does anyone think it is important to have a high resolution thumbnail (posterframe)? If it is important, we could look at the video dimensions and if it is HD, output an HD thumbnail. See https://en.wikipedia.org/wiki/Pixel_aspect_ratio