### PR TITLE
Improve the popularity algorithm

### DIFF
--- a/scripts/mediaViews.php
+++ b/scripts/mediaViews.php
@@ -11,19 +11,25 @@ $media_hub = new UNL_MediaHub();
 $db = Doctrine_Manager::getInstance()->getCurrentConnection();
 
 //prune logs
-$date = date('Y-m-d H:i:s', strtotime('1 month ago'));
-
-$sql = "DELETE FROM media_views WHERE datecreated < ?";
+$sql = "DELETE FROM media_views WHERE datecreated < (NOW() - INTERVAL 1 MONTH)";
 $q   = $db->prepare($sql);
-$q->execute(array($date));
+$q->execute();
 
-//Update popular counts
-$sql = "UPDATE media
+//Update popular counts (more of a weight than an acutal count)
+$sql = "
+UPDATE media
 INNER JOIN (
     SELECT media_id, COUNT(*) AS total_views
     FROM media_views
+    WHERE media_views.datecreated > (NOW() - INTERVAL 1 WEEK)
     GROUP BY media_id
-  ) AS counts ON media.id = counts.media_id
-SET popular_play_count = counts.total_views";
+  ) AS seven_day_counts ON media.id = seven_day_counts.media_id
+INNER JOIN (
+    SELECT media_id, COUNT(*) AS total_views
+    FROM media_views
+    WHERE media_views.datecreated > (NOW() - INTERVAL 30 DAY)
+    GROUP BY media_id
+  ) AS thirty_day_counts ON media.id = thirty_day_counts.media_id
+SET popular_play_count = round(seven_day_counts.total_views + thirty_day_counts.total_views*.5 + media.play_count*.15)";
 $q   = $db->prepare($sql);
 $q->execute();

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -33,11 +33,13 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
     function getTopMedia()
     {
         $options = array(
-            'limit'   => null,
+            'limit'   => 10000000,
             'orderby' => 'popular_play_count'
         );
         $top_media = new UNL_MediaHub_MediaList($options);
         $top_media->run();
+
+        $after_date = strtotime('6 months ago');
         
         //return $top_media->items;
         $limit = 6;
@@ -47,6 +49,11 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
             if (count($media_list) >= $limit) {
                 //Break out of the loop once we have reached 6 videos
                 break;
+            }
+
+            if (strtotime($media->datecreated) < $after_date) {
+                //We only want media that was added in the last 4 months
+                continue;
             }
 
             //Get the media's feeds

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -52,7 +52,7 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
             }
 
             if (strtotime($media->datecreated) < $after_date) {
-                //We only want media that was added in the last 4 months
+                //We only want media that was added recently
                 continue;
             }
 


### PR DESCRIPTION
This improves the popular media band on the home page by making it more dynamic.

I started with improving the popularity algorithm by doing the following:

- Changes the popular_count to hold an integer that reflects a weight value rather than an actual count. That value is calculated by
   - seven day play count * .75
   - +thirty day play count * .5
   - +total plays * .15

That improved results, but there was still a lot of sway on really old videos that have seen a lot of views (67000*.15 is still 10k), which ended up making the popular media band very similar to what it is right now. To improve this, I also put a filter in to restrict videos in the band to ones created in the last 6 months. 6 months may still be too long, but we can always adjust it later.

Another solution could have been to remove the total plays from the algorithm, but you can sort all media by the popular play count when browsing media, and I thought that part of the algorithm was valuable for that circumstance.

