### PR TITLE
Redirect to the custom poster URL if it is set

### DIFF
--- a/src/UNL/MediaHub/Media/Image.php
+++ b/src/UNL/MediaHub/Media/Image.php
@@ -35,6 +35,12 @@ class UNL_MediaHub_Media_Image
         if (!$media = UNL_MediaHub_Media::getById($media_id)) {
             throw new \Exception('media not found', 404);
         }
+        
+        if (!empty($media->poster)) {
+            //handle custom posters
+            UNL_MediaHub::redirect($media->poster);
+            exit();
+        }
 
         //Does the current user have permission?
         $user = UNL_MediaHub_AuthService::getInstance()->getUser();


### PR DESCRIPTION
Note: the cached poster file will need to be removed for this to work.