### PR TITLE
Reduce the priority of heavy ffmpeg related tasks

### DIFF
--- a/src/UNL/MediaHub/Media/Image.php
+++ b/src/UNL/MediaHub/Media/Image.php
@@ -79,7 +79,7 @@ class UNL_MediaHub_Media_Image
             mkdir($directory, 0777, true);
         }
         
-        exec(UNL_MediaHub::getFfmpegPath() . " -i $url -ss $time -vcodec mjpeg -vframes 1 -f image2 $file -y", $return, $status);
+        exec('nice ' . UNL_MediaHub::getFfmpegPath() . " -i $url -ss $time -vcodec mjpeg -vframes 1 -f image2 $file -y", $return, $status);
 
         if ($status == 0 && file_exists($file)) {
             $media->dateupdated = date('Y-m-d H:i:s');

--- a/src/UNL/MediaHub/Muxer.php
+++ b/src/UNL/MediaHub/Muxer.php
@@ -84,7 +84,7 @@ class UNL_MediaHub_Muxer
         $tmp_media_file = UNL_MediaHub::getRootDir() . '/tmp/' . $this->media->id . '.' . $local_file_name_extension;
         
         //This should copy the video and audio tracks while replacing the subtitle tracks. Thus, old subtitles will be removed.
-        $command = UNL_MediaHub::getFfmpegPath();
+        $command = 'nice ' . UNL_MediaHub::getFfmpegPath();
         $command .= ' -y'; //overwrite output files
         $command .= ' -i ' . $video_file; //Video input is test.mp4
         foreach ($subtitles as $subtitle) {


### PR DESCRIPTION
By prefixing these commands with `nice`, the cpu scheduling priority for potentially heavy tasks will be reduced, freeing up resources for more important things like actually rendering pages.