### PR TITLE
Add a warning for unsafe video codecs

### DIFF
--- a/tests/UNL/Mediahub/MediaDBTest.php
+++ b/tests/UNL/Mediahub/MediaDBTest.php
@@ -101,4 +101,24 @@ class UNL_MediaHub_MediaDBTest extends UNL_MediaHub_DBTests_DBTestCase
         //Make sure an accurate duration was detected
         $this->assertEquals(new UNL_MediaHub_DurationHelper(295222), $duration, 'an accurate duration should have been detected');
     }
+
+    /**
+     * @test
+     */
+    public function getCodec()
+    {
+        $this->prepareTestDB();
+        $data_dir = dirname(dirname(__DIR__)) . '/data';
+
+        $media_a = UNL_MediaHub_Media::getById(1);
+
+        //Copy over a working file to test
+        copy($data_dir.'/muxed.mp4', UNL_MediaHub::getRootDir() . '/www/uploads/a.mp4');
+        $this->assertEquals('AVC', $media_a->getCodec());
+
+        //Now make sure the bad codec was detected
+        copy($data_dir.'/bad-codec.mp4', UNL_MediaHub::getRootDir() . '/www/uploads/a.mp4');
+
+        $this->assertEquals('MPEG-4 Visual', $media_a->getCodec());
+    }
 }

--- a/www/manager/templates/html/Feed/Media/Form.tpl.php
+++ b/www/manager/templates/html/Feed/Media/Form.tpl.php
@@ -31,27 +31,43 @@ $controller->setReplacementData('head', $js);
 ?>
 
 <?php if(empty($context->media->media_text_tracks_id)): ?>
-<div class="wdn_notice alert mh-caption-alert">
-    <div class="close">
-        <a href="#" title="Close this notice">Close this notice</a>
-    </div>
-    <div class="message">
-        <h4>This Video is Missing Captions!</h4>
-        <div class="mh-caption-band">
-            <p>
-                For accessibility reasons, captions are required for <strong>all</strong> videos.
-            </p>
-            <p>
-                <a class="wdn-button" href="<?php echo $edit_caption_url ?>">Caption Your Video</a>
-            </p>
+    <div class="wdn_notice alert mh-caption-alert">
+        <div class="message">
+            <h4>This Video is Missing Captions!</h4>
+            <div class="mh-caption-band">
+                <p>
+                    For accessibility reasons, captions are required for <strong>all</strong> videos.
+                </p>
+                <p>
+                    <a class="wdn-button" href="<?php echo $edit_caption_url ?>">Caption Your Video</a>
+                </p>
+            </div>
         </div>
     </div>
-</div>
+    
+    <script type="text/javascript">
+    WDN.initializePlugin('notice');
+    </script>
+<?php endif; ?>
 
-<script type="text/javascript">
-WDN.initializePlugin('notice');
-</script>
+<?php if (!$context->media->isWebSafe()): ?>
+    <div class="wdn_notice alert mh-caption-alert">
+        <div class="message">
+            <h4>This video might not work on the web!</h4>
+            <div class="mh-caption-band">
+                <p>
+                    This video was encoded with '<?php echo $context->media->getCodec() ?>', which is not safe for the web, and might not work on every device/browser. Please run the video through HandBrake and swap the video out.
+                </p>
+                <p>
+                    <a class="wdn-button" href="http://wdn.unl.edu/documentation/unl-mediahub/using-handbrake">How to use HandBrake</a>
+                </p>
+            </div>
+        </div>
+    </div>
 
+    <script type="text/javascript">
+        WDN.initializePlugin('notice');
+    </script>
 <?php endif; ?>
 
 <form action="?" method="post" name="media_form" id="media_form" class="wdn-band" enctype="multipart/form-data">


### PR DESCRIPTION
the 'MPEG-4 Visual' is not safe and won't play in Internet Explorer, FireFox, and possibly other browsers/devices. This will display a warning on the edit page for the media, prompting the user to run the video through our HandBrake presets and re-upload.