### PR TITLE
Add headers to force download media in web browser

### DIFF
--- a/data/routes.php
+++ b/data/routes.php
@@ -25,6 +25,7 @@ $routes['/^media\/(?P<id>[0-9]+)\/image(\.[\w]+)?$/'] = 'media_image';
 $routes['/^media\/((?P<id>[0-9]+)\/)?embed(\/(?P<version>[0-9]+))?$/'] = 'media_embed';
 
 $routes['/^media\/(?P<id>[0-9]+)\/file(\.[\w]+)?$/'] = 'media_file';
+$routes['/^media\/(?P<id>[0-9]+)\/download$/'] = 'media_file_download';
 
 $routes['/^media\/(?P<id>[0-9]+)$/'] = 'media';
 

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -271,6 +271,18 @@ class UNL_MediaHub_Controller
             case 'media_file':
                 $this->output[] = UNL_MediaHub_Media_File::getById($this->options['id']);
                 break;
+            case 'media_file_download':
+                if (!$media = UNL_MediaHub_Media::getById($this->options['id'])) {
+                    throw new \Exception('media not found', 404);
+                }
+                $file = $media->getLocalFileName();
+                $path_info = pathinfo($file);
+                header('Content-Description: Media File Download');
+                header('Content-Type: application/octet-stream');
+                header('Content-Disposition: attachment; filename="'.$media->title.'.'.$path_info['extension'].'"');
+                header('Content-Length: ' . filesize($file));
+                readfile($file);
+                exit;
             default:
                 $this->output[] = new $this->options['model']($this->options);
             }

--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -213,7 +213,7 @@ $getTracks = $context->getTextTrackURLs();
 
                     <a class="wdn-button embed mh-hide-bp2"><span class="wdn-icon-plus wdn-icon" aria-hidden="true"></span>Embed</a>
                     <br>
-                    <a href="<?php echo htmlentities($context->getMediaURL(), ENT_QUOTES); ?>" target="_blank" class="wdn-button mh-hide-bp2"><span class="wdn-icon-up-small mh-flip-180 wdn-icon" aria-hidden="true"></span>Download</a>
+                    <a href="<?php echo htmlentities($controller->getURL($context).'/download', ENT_QUOTES); ?>" target="_blank" class="wdn-button mh-hide-bp2"><span class="wdn-icon-up-small mh-flip-180 wdn-icon" aria-hidden="true"></span>Download</a>
 
                 </div>
 


### PR DESCRIPTION
Added a new route 'media/$id/download' in routes.php and set headers to force download the media file in the browser.

Users can now download the file when clicked on the download button in the media page.
 