### PR TITLE
Prevent memory exhausted error

### DIFF
--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -281,6 +281,7 @@ class UNL_MediaHub_Controller
                 header('Content-Type: application/octet-stream');
                 header('Content-Disposition: attachment; filename="'.$media->title.'.'.$path_info['extension'].'"');
                 header('Content-Length: ' . filesize($file));
+                ob_end_flush();
                 readfile($file);
                 exit;
             default:


### PR DESCRIPTION
http://php.net/manual/en/function.readfile.php
readfile() will not present any memory issues, even when sending large files, on its own. If you encounter an out of memory error ensure that output buffering is off with ob_get_level().