### PR TITLE
Ensure that the video fits its container

### DIFF
--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -49,7 +49,7 @@ $getTracks = $context->getTextTrackURLs();
 
 <div class="wdn-band mh-video-band">
     <div class="wdn-inner-wrapper">
-        <div class="mh-iframe-wrapper">
+        <div class="wdn-responsive-embed wdn-aspect16x9">
             <iframe height="667" src="<?php echo $controller->getURL($context)?>?format=iframe&autoplay=1" allowfullscreen title="watch media"></iframe>
         </div>
     </div>

--- a/www/templates/html/MediaPlayer/v3/player.tpl.php
+++ b/www/templates/html/MediaPlayer/v3/player.tpl.php
@@ -25,7 +25,7 @@
             videoWidth: '100%',
             videoHeight: '100%',
             controls: true,
-            fluid: true
+            fluid: false
         };
         <?php endif; ?>
 


### PR DESCRIPTION
Some videos that were not 16:9 were overflowing the container and thus not fully displaying.