### PR TITLE
Optimize videos that are swapped

### DIFF
--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -185,6 +185,11 @@ class UNL_MediaHub_Controller
         case 'js':
             header('Content-type: text/javascript');
             break;
+        case 'iframe':
+            if ('media' === $this->options['model']) {
+                header_remove('X-Frame-Options');
+            }
+            break;
         default:
             break;
         }

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -222,7 +222,7 @@ class UNL_MediaHub_Controller
                 $transcoding_job = $media->getMostRecentTranscodingJob();
                 
                 if ($transcoding_job && $transcoding_job->isPending()) {
-                    throw new Exception('This media is being optimized. Please try back later.', 403);
+                    throw new Exception('This media is being optimized. Please try back later.', 200);
                 }
 
                 if ($transcoding_job && $transcoding_job->isError()) {

--- a/src/UNL/MediaHub/Manager/PostHandler.php
+++ b/src/UNL/MediaHub/Manager/PostHandler.php
@@ -379,6 +379,12 @@ class UNL_MediaHub_Manager_PostHandler
                     rename($new_local_file, $local_file); //Replace the old one (keeping its name).
                     $this->post['url'] = $media->url; //Don't update the URL of the file
 
+                    $transcoding_job = $media->getMostRecentTranscodingJob();
+                    if ($transcoding_job) {
+                        //re-transcode this version if the previous job was also transcoded
+                        $media->transcode($transcoding_job->job_type);
+                    }
+
                 } else if ($local_file && !is_dir($local_file)) {
                     //New file is not local, but old one is. Delete the old one.
                     unlink($local_file);
@@ -529,7 +535,13 @@ class UNL_MediaHub_Manager_PostHandler
             );
             UNL_MediaHub_Manager::addNotice($notice);
             
-            UNL_MediaHub::redirect(UNL_MediaHub_Controller::getURL($media));
+            $last_job = $media->getMostRecentTranscodingJob();
+            
+            if (!$last_job->isFinished()) {
+                UNL_MediaHub::redirect(UNL_MediaHub_Manager::getURL() . '?view=addmedia&id='.$media->id);
+            } else {
+                UNL_MediaHub::redirect(UNL_MediaHub_Controller::getURL($media));
+            }
         }
         
     }

--- a/src/UNL/MediaHub/Manager/PostHandler.php
+++ b/src/UNL/MediaHub/Manager/PostHandler.php
@@ -378,16 +378,15 @@ class UNL_MediaHub_Manager_PostHandler
                     //Both files are local.
                     rename($new_local_file, $local_file); //Replace the old one (keeping its name).
                     $this->post['url'] = $media->url; //Don't update the URL of the file
-
-                    $transcoding_job = $media->getMostRecentTranscodingJob();
-                    if ($transcoding_job) {
-                        //re-transcode this version if the previous job was also transcoded
-                        $media->transcode($transcoding_job->job_type);
-                    }
-
                 } else if ($local_file && !is_dir($local_file)) {
                     //New file is not local, but old one is. Delete the old one.
                     unlink($local_file);
+                }
+
+                $transcoding_job = $media->getMostRecentTranscodingJob();
+                if ($transcoding_job) {
+                    //re-transcode this version if the previous job was also transcoded
+                    $media->transcode($transcoding_job->job_type);
                 }
             }
             

--- a/www/index.php
+++ b/www/index.php
@@ -29,6 +29,8 @@ if (isset($cache)) {
     $outputcontroller->setCacheInterface($cache);
 }
 
+header('X-Frame-Options: SAMEORIGIN');
+
 switch($controller->options['format']) {
     case 'xml':
     case 'mosaic-xml':

--- a/www/manager/templates/html/Feed/Media/Form.tpl.php
+++ b/www/manager/templates/html/Feed/Media/Form.tpl.php
@@ -1,6 +1,11 @@
 <script>
+    <?php if ($user->canTranscode()): ?>
+    const MAX_UPLOAD = "<?php echo UNL_MediaHub_Controller::$max_upload_mb*10 ?>";
+    const VALID_VIDEO_EXTNESIONS = "mp4,mov";
+    <?php else: ?>
     const MAX_UPLOAD = "<?php echo UNL_MediaHub_Controller::$max_upload_mb ?>";
     const VALID_VIDEO_EXTNESIONS = "mp4";
+    <?php endif ?>
 </script>
 
 <?php
@@ -166,10 +171,15 @@ $controller->setReplacementData('head', $js);
             <div class="wdn-grid-set">
                 <div class="bp2-wdn-col-two-sevenths wdn-pull-right">
                     <ol>
-                        <?php if (!$transcoding_job): ?>
-                            <li>
-                                <?php if ($user->canTranscode()): ?>
-                                    <p><span class="wdn-icon-attention" aria-hidden="true"></span><span class="wdn-text-hidden">Notice:</span> New uploads will NOT be automatically optimized. You MUST use HandBrake.</p>
+                        <li>
+                            <?php if ($transcoding_job && !$transcoding_job->isFinished()): ?>
+                                <p>Swapping media is disabled while a video is being optimized.</p>
+                            <?php else: ?>
+                                <?php if ($transcoding_job): ?>
+                                    <p><span class="wdn-icon-attention" aria-hidden="true"></span><span class="wdn-text-hidden">Notice:</span> Swapping media will cause the media to be unavailable while the upload is optimized. This upload will be optimized with the same settings as the current version.</p>
+                                <?php endif; ?>
+                                <?php if (!$transcoding_job): ?>
+                                    <p><span class="wdn-icon-attention" aria-hidden="true"></span><span class="wdn-text-hidden">Notice:</span> You MUST use HandBrake to optimize the new video.</p>
                                 <?php endif; ?>
                                 <div id="mh_upload_media_container">
                                     <div id="mh_upload_media" class="mh-upload-box mh-upload-box-small wdn-center">
@@ -183,10 +193,8 @@ $controller->setReplacementData('head', $js);
                                         Your browser doesn't have Flash, Silverlight or HTML5 support.
                                     </div>
                                 </div>
-                            </li>
-                        <?php else: ?>
-                            <li>Optimized media can not be replaced with a new upload.</li>
-                        <?php endif; ?>
+                            <?php endif; ?>
+                        </li>
                         <li>
                             <?php echo $savvy->render($context, 'Feed/Media/fields/privacy.tpl.php'); ?>
                         </li>

--- a/www/templates/html/DefaultHomepage.tpl.php
+++ b/www/templates/html/DefaultHomepage.tpl.php
@@ -9,7 +9,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     <div class="mh-search-container">
         <div class="mh-search-image">
             <div id="video-container">
-                <video id="video-player" preload="metadata" autoplay="autoplay" loop="" class="fillWidth">
+                <video id="video-player" preload="metadata" autoplay="autoplay"  loop="" muted class="fillWidth">
                     <source src="<?php echo $baseUrl ?>templates/html/featured-video/blurdarklights.mp4" type="video/mp4">
                     <source src="<?php echo $baseUrl ?>templates/html/featured-video/blurdarklights.webm" type="video/webm">
                     <source src="<?php echo $baseUrl ?>templates/html/featured-video/blurdarklights.ogv" type="video/ogg">


### PR DESCRIPTION
This will optimize videos that were swapped IF the previous version of the media was optimized. This will result in the video being unavailable while the new version is being optimized.

This also fixes an error with the video background on the home page.