### PR TITLE
Fix HLS captions toggle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
-- 5.5
 - 5.6
+- 7.0
+- 7.2
 addons:
   apt:
     packages:

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
       "captioning/captioning": "2.*",
       "php": ">=5.5.0", 
       "leodido/langcode-conv": "^0.2.0",
-      "mhor/php-mediainfo": "^3.0",
+      "mhor/php-mediainfo": "^4.1",
         "ramsey/uuid": "^3.7",
         "aws/aws-sdk-php": "^3.52",
         "moontoast/math": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f01f209feddf25a9c2bfc7e7b7112d7",
+    "content-hash": "4bc4b8195adcc6cd839ed90ae6c40b80",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -88,16 +88,16 @@
         },
         {
             "name": "captioning/captioning",
-            "version": "2.3.1",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/captioning/captioning.git",
-                "reference": "b56b2506e32e7e2d109cbce6c006ecd93fe04a2b"
+                "reference": "d830685b5a942b944d06d97a86eddc8de032e2c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/captioning/captioning/zipball/b56b2506e32e7e2d109cbce6c006ecd93fe04a2b",
-                "reference": "b56b2506e32e7e2d109cbce6c006ecd93fe04a2b",
+                "url": "https://api.github.com/repos/captioning/captioning/zipball/d830685b5a942b944d06d97a86eddc8de032e2c1",
+                "reference": "d830685b5a942b944d06d97a86eddc8de032e2c1",
                 "shasum": ""
             },
             "require": {
@@ -130,12 +130,12 @@
                 "srt",
                 "ssa",
                 "subrip",
-                "subtation",
+                "substation",
                 "subtitle",
                 "vtt",
                 "webvtt"
             ],
-            "time": "2016-07-20T21:02:04+00:00"
+            "time": "2018-01-26T11:25:24+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -575,30 +575,30 @@
         },
         {
             "name": "mhor/php-mediainfo",
-            "version": "3.0.0",
+            "version": "4.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mhor/php-mediainfo.git",
-                "reference": "a16bad2b884dc17d40fcea432115ec0c3ec0e739"
+                "reference": "ebcf39d68d3b2c70a34798ea4132fe8b457ee295"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mhor/php-mediainfo/zipball/a16bad2b884dc17d40fcea432115ec0c3ec0e739",
-                "reference": "a16bad2b884dc17d40fcea432115ec0c3ec0e739",
+                "url": "https://api.github.com/repos/mhor/php-mediainfo/zipball/ebcf39d68d3b2c70a34798ea4132fe8b457ee295",
+                "reference": "ebcf39d68d3b2c70a34798ea4132fe8b457ee295",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "symfony/filesystem": "~2.3|~3.0",
-                "symfony/process": "~2.3|~3.0"
+                "php": ">=5.6.0",
+                "symfony/filesystem": "~2.3|~3.0|~4.0",
+                "symfony/process": "~2.3|~3.0|~4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -617,7 +617,7 @@
                 }
             ],
             "description": "PHP wrapper around the mediainfo command",
-            "time": "2017-01-17T22:45:20+00:00"
+            "time": "2018-07-03T21:29:10+00:00"
         },
         {
             "name": "moontoast/math",

--- a/www/templates/iframe/js/vendor/videojs-captions-toggle.js
+++ b/www/templates/iframe/js/vendor/videojs-captions-toggle.js
@@ -6,7 +6,7 @@ function toggleSingleCaptionTrack(options) {
         var mq = window.matchMedia( "(min-width: 1024px)" );
         var Button = videojs.getComponent("subsCapsButton");
         var activeTextTrackCount = 0;
-        var activeTextTractIndex = 0;
+        var activeTextTrack;
         
         var ToggleCaptionsButton = videojs.extend(Button, {
           constructor: function(player, options) {
@@ -29,14 +29,14 @@ function toggleSingleCaptionTrack(options) {
                   Button.prototype.pressButton.call(this);
               } else {
                   //We are on mobile (or at least at a mobile width)
-                  if (activeTextTrackCount === 1) {
+                  if (activeTextTrackCount === 1 && activeTextTrack) {
                       //Only one caption track was found. Just toggle it
-                      if(textTracks[activeTextTractIndex].mode === "showing"){
-                          textTracks[activeTextTractIndex].mode = "disabled";
-                      }else{
-                          textTracks[activeTextTractIndex].mode = "showing";
+                      if(activeTextTrack.mode === "showing") {
+                          activeTextTrack.mode = "disabled";
+                      } else {
+                          activeTextTrack.mode = "showing";
                       }
-                      CheckCaptionsShowing(textTracks[activeTextTractIndex], MyToggleCaptionsButton);
+                      CheckCaptionsShowing(activeTextTrack, MyToggleCaptionsButton);
                   } else {
                       //More than one caption track was found, so we need to display a list
                       //Disable the caption settings menu item because it doesn't work on mobile
@@ -61,7 +61,7 @@ function toggleSingleCaptionTrack(options) {
             for(var i = 0; i < textTracks.length; ++i){
                 if(textTracks[i].kind === 'captions') {
                     activeTextTrackCount++;
-                    activeTextTractIndex = i;
+                    activeTextTrack = textTracks[i];
                 }
             }
             if (activeTextTrackCount === 1 && !mq.matches) {
@@ -71,7 +71,7 @@ function toggleSingleCaptionTrack(options) {
                 MyToggleCaptionsButton.removeClass('toggle');
             }
 
-            CheckCaptionsShowing(textTracks[activeTextTractIndex], MyToggleCaptionsButton);
+            CheckCaptionsShowing(activeTextTrack, MyToggleCaptionsButton);
         }
         
         //Initialize text track change


### PR DESCRIPTION
The HLS library will add a metadata text track and then remove it after the video loads. This changes the indexes of the text tracks, and for whatever reason this change does not cause `textTracks.on("change")` to be called. Thus, depending on an index value was not safe and resulted in an error under some circumstances.