### PR TITLE
Remove `white-space: nowrap` from `.mh-count`

### DIFF
--- a/www/templates/html/css/all.css
+++ b/www/templates/html/css/all.css
@@ -572,7 +572,7 @@ Supporting styles for individual presentation of channel pages
 
 .mh-channel-maintainers-list {
     font-size: .85em;
-}/* 
+}/*
 -------------------------------------------------
 Supporting styles for listings of channels
 -------------------------------------------------
@@ -642,7 +642,6 @@ Supporting styles for listings of channels
 .mh-stat .mh-count {
 	font-size: 1.5em;
 	display: block;
-	white-space: nowrap;
 }
 
 .mh-stat .mh-context {
@@ -688,7 +687,7 @@ p.mh-more-info a {
 	.mh-media-samples li:nth-child(n+5) {
 		display: none;
 	}
-	
+
 	.mh-feed-stats {
 		display: none;
 	}

--- a/www/templates/html/css/channellist.css
+++ b/www/templates/html/css/channellist.css
@@ -1,4 +1,4 @@
-/* 
+/*
 -------------------------------------------------
 Supporting styles for listings of channels
 -------------------------------------------------
@@ -68,7 +68,6 @@ Supporting styles for listings of channels
 .mh-stat .mh-count {
 	font-size: 1.5em;
 	display: block;
-	white-space: nowrap;
 }
 
 .mh-stat .mh-context {
@@ -114,7 +113,7 @@ p.mh-more-info a {
 	.mh-media-samples li:nth-child(n+5) {
 		display: none;
 	}
-	
+
 	.mh-feed-stats {
 		display: none;
 	}


### PR DESCRIPTION
Remove `white-space: nowrap` to prevent long strings of content breaking out of the grid.