### PR TITLE
Update canView to only check user auth if needed

### DIFF
--- a/lib/php/Doctrine/Connection/UnitOfWork.php
+++ b/lib/php/Doctrine/Connection/UnitOfWork.php
@@ -237,7 +237,7 @@ class Doctrine_Connection_UnitOfWork extends Doctrine_Connection_Module
                 $params = array();
                 $columnNames = array();
                 foreach ($identifierMaps as $idMap) {
-                    while (list($fieldName, $value) = each($idMap)) {
+                    foreach ($idMap as $fieldName => $value) {
                         $params[] = $value;
                         $columnNames[] = $table->getColumnName($fieldName);
                     }

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -235,20 +235,7 @@ class UNL_MediaHub_Controller
                     throw new Exception('There was an error optimizing this media.', 500);
                 }
 
-                $user = UNL_MediaHub_AuthService::getInstance()->getUser();
-                if (!$media->canView($user)) {
-                    $message = 'You do not have permission to view this.';
-                    if (empty($user)) {
-                        if ($media->privacy == 'PROTECTED') {
-                            $message = "This media is 'PROTECTED' and may only be viewed by logged in users.  If you have an account, please log in to view.";
-                        } elseif ($media->privacy == 'PRIVATE') {
-                            $message = "This media is 'PRIVATE' and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
-                        } elseif (!$media->meetsCaptionRequirement()) {
-                            $message = "This media is not published and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
-                        }
-                    }
-                    throw new Exception($message, 403);
-                }
+                $this->canView($media);
                 
                 if (!$media->meetsCaptionRequirement()) {
                     $notice = new UNL_MediaHub_Notice(
@@ -293,20 +280,7 @@ class UNL_MediaHub_Controller
                 
                 $media_embed = UNL_MediaHub_Media_Embed::getById($id, $version, $this->options);
 
-                $user = UNL_MediaHub_AuthService::getInstance()->getUser();
-                if (!$media_embed->canView($user)) {
-                    $message = 'You do not have permission to view this.';
-                    if (empty($user)) {
-                        if ($media_embed->privacy == 'PROTECTED') {
-                            $message = "This media is 'PROTECTED' and may only be viewed by logged in users.  If you have an account, please log in to view.";
-                        } elseif ($media_embed->privacy == 'PRIVATE') {
-                            $message = "This media is 'PRIVATE' and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
-                        } elseif (!$media_embed->meetsCaptionRequirement()) {
-                            $message = "This media is not published and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
-                        }
-                    }
-                    throw new Exception($message, 403);
-                }
+                $this->canView($media_embed);
                 
                 $this->output[] = $media_embed;
                 
@@ -345,6 +319,20 @@ class UNL_MediaHub_Controller
         } catch(Exception $e) {
             $this->output[] = $e;
         }
+    }
+
+    function canView($media) {
+      if (!$media->canView()) {
+        $message = 'You do not have permission to view this.';
+        if ($media->privacy == 'PROTECTED') {
+          $message = "This media is 'PROTECTED' and may only be viewed by logged in users.  If you have an account, please log in to view.";
+        } elseif ($media->privacy == 'PRIVATE') {
+          $message = "This media is 'PRIVATE' and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
+        } elseif (!$media->meetsCaptionRequirement()) {
+          $message = "This media is not published and may only be viewed by logged in users with proper channel access.  If you have an account and access, please log in to view.";
+        }
+        throw new Exception($message, 403);
+      }
     }
 
     /**

--- a/src/UNL/MediaHub/Media.php
+++ b/src/UNL/MediaHub/Media.php
@@ -605,7 +605,7 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
     /**
      * @return bool
      */
-    public function canView($user)
+    public function canView(UNL_MediaHub_User $user = NULL)
     {
         $requires_membership = false;
         
@@ -622,9 +622,14 @@ class UNL_MediaHub_Media extends UNL_MediaHub_Models_BaseMedia implements UNL_Me
         if (!$requires_membership) {
             return true;
         }
+
+        // get user if not passed in
+        if (empty($user)) {
+            $user = UNL_MediaHub_AuthService::getInstance()->getUser();
+        }
         
         //At this point a user needs to be logged in.
-        if (!$user) {
+        if (!($user instanceof UNL_MediaHub_User)) {
             return false;
         }
 

--- a/src/UNL/MediaHub/Media/Embed.php
+++ b/src/UNL/MediaHub/Media/Embed.php
@@ -52,7 +52,7 @@ class UNL_MediaHub_Media_Embed
         return $this->media->meetsCaptionRequirement();
     }
 
-    public function canView($user)
+    public function canView(UNL_MediaHub_User $user = NULL)
     {
         return $this->media->canView($user);
     }

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -32,7 +32,7 @@ switch ($code) {
     });
 </script>
 <div class="dcf-mt-8 dcf-mb-8 wdn_notice alert">
-    <div class="message">
+    <div class="message" style="color: #fff;">
         <h1 class="title"><?php echo $title; ?></h1>
         <p><?php echo UNL_MediaHub::escape($context->getMessage()); ?></p>
     </div>

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -4,13 +4,6 @@ if (false == headers_sent()
     header('HTTP/1.1 '.$code);
     header('Status: '.$code);
 }
-<script>
-    window.addEventListener('inlineJSReady', function(e) {
-        require(['wdn'], function(wdn) {
-            wdn.initializePlugin('notice');
-        });
-    });
-</script>
 
 switch ($code) {
     case 200:
@@ -31,6 +24,13 @@ switch ($code) {
 }
 ?>
 
+<script>
+    window.addEventListener('inlineJSReady', function(e) {
+        require(['wdn'], function(wdn) {
+            wdn.initializePlugin('notice');
+        });
+    });
+</script>
 <div class="dcf-mt-8 dcf-mb-8 wdn_notice alert">
     <div class="message">
         <h1 class="title"><?php echo $title; ?></h1>

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -1,6 +1,5 @@
 <?php
-if (false == headers_sent()
-    && $code = $context->getCode()) {
+if (false == headers_sent() && $code = $context->getCode()) {
     header('HTTP/1.1 '.$code);
     header('Status: '.$code);
 }
@@ -22,6 +21,7 @@ switch ($code) {
         $title = 'Whoops! Sorry, there was an error.';
         break;
 }
+
 ?>
 
 <script>

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -4,7 +4,13 @@ if (false == headers_sent()
     header('HTTP/1.1 '.$code);
     header('Status: '.$code);
 }
-$page->addScriptDeclaration("WDN.initializePlugin('notice')");
+<script>
+    window.addEventListener('inlineJSReady', function(e) {
+        require(['wdn'], function(wdn) {
+            wdn.initializePlugin('notice');
+        });
+    });
+</script>
 
 switch ($code) {
     case 200:

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -31,8 +31,8 @@ switch ($code) {
         });
     });
 </script>
-<div class="dcf-mt-8 dcf-mb-8 wdn_notice alert">
-    <div class="message" style="color: #fff; padding: 6px;">
+<div class="dcf-mt-8 dcf-mb-8 wdn_notice alert" style="padding: 6px;">
+    <div class="message" style="color: #fff;">
         <h1 class="title"><?php echo $title; ?></h1>
         <p><?php echo UNL_MediaHub::escape($context->getMessage()); ?></p>
     </div>

--- a/www/templates/html/Exception.tpl.php
+++ b/www/templates/html/Exception.tpl.php
@@ -32,7 +32,7 @@ switch ($code) {
     });
 </script>
 <div class="dcf-mt-8 dcf-mb-8 wdn_notice alert">
-    <div class="message" style="color: #fff;">
+    <div class="message" style="color: #fff; padding: 6px;">
         <h1 class="title"><?php echo $title; ?></h1>
         <p><?php echo UNL_MediaHub::escape($context->getMessage()); ?></p>
     </div>


### PR DESCRIPTION
The following changes were made so that public media in iframes does not trigger a user auth check, which is causing some display issues.  Addresses issue: https://github.com/unl/UNL_MediaHub/issues/392 

Note: This branch is now on mediahub-test.unl.edu

Updates made include:
* The core `canView` method now has `$user` as an optional parameter
* The core `canView` method will only lookup up user if not passed in and it determines an user auth check is required.
* The Exception template to render in min fashion if the WDN framework is not available, i.e. when in an iframe.
* Replaced deprecated `each` 
