### PR TITLE
Change oEmbed "provider" response parameter to "provider_name"

### DIFF
--- a/www/templates/html/Media/Oembed.tpl.php
+++ b/www/templates/html/Media/Oembed.tpl.php
@@ -14,7 +14,7 @@ $details = array(
     'version' => '1.0',
     'title' => UNL_MediaHub::escape($context->media->title),
     'author_name' => UNL_MediaHub::escape($context->media->author),
-    'provider' => 'UNL Mediahub',
+    'provider_name' => 'UNL Mediahub',
     'provider_url' => UNL_MediaHub_Controller::$url
 );
 


### PR DESCRIPTION
The oEmbed endpoint is returning an invalid parameter, "provider". This parameter should be named "provider_name". See https://oembed.com/#section2.3.