### PR TITLE
Remove Oembed escaping for title and author

### DIFF
--- a/www/templates/html/Media/Oembed.tpl.php
+++ b/www/templates/html/Media/Oembed.tpl.php
@@ -12,8 +12,8 @@ class SimpleXMLExtended extends SimpleXMLElement
 
 $details = array(
     'version' => '1.0',
-    'title' => addslashes($context->media->title),
-    'author_name' => addslashes($context->media->author),
+    'title' => strip_tags($context->media->title),
+    'author_name' => strip_tags($context->media->author),
     'provider_name' => 'UNL Mediahub',
     'provider_url' => UNL_MediaHub_Controller::$url
 );

--- a/www/templates/html/Media/Oembed.tpl.php
+++ b/www/templates/html/Media/Oembed.tpl.php
@@ -12,8 +12,8 @@ class SimpleXMLExtended extends SimpleXMLElement
 
 $details = array(
     'version' => '1.0',
-    'title' => UNL_MediaHub::escape($context->media->title),
-    'author_name' => UNL_MediaHub::escape($context->media->author),
+    'title' => addslashes($context->media->title),
+    'author_name' => addslashes($context->media->author),
     'provider_name' => 'UNL Mediahub',
     'provider_url' => UNL_MediaHub_Controller::$url
 );


### PR DESCRIPTION
Can test on https://mediahub-test.unl.edu/

Updated Sample usage:
* https://mediahub-test.unl.edu/oembed?url=https%3A%2F%2Fmediahub-test.unl.edu%2Fmedia%2F37 (defaults to json output)
* https://mediahub-test.unl.edu/oembed?url=https%3A%2F%2Fmediahub-test.unl.edu%2Fmedia%2F37&format=json (specify json output)
* https://mediahub-test.unl.edu/oembed?url=https%3A%2F%2Fmediahub-test.unl.edu%2Fmedia%2F37&format=xml (specify xml output)
