### PR TITLE
UNL_MediaHub::checkMetadataProjection() should count streams

### DIFF
--- a/src/UNL/MediaHub.php
+++ b/src/UNL/MediaHub.php
@@ -258,7 +258,7 @@ class UNL_MediaHub
         }
 
         $projection = false;
-        $length = count($metadata);
+        $length = count($metadata->streams);
         for ($i=0; $i < $length; $i++) { 
             if(isset($metadata->streams[$i]->side_data_list)){
                 $side_data_list_length = sizeof($metadata->streams[$i]->side_data_list);

--- a/src/UNL/MediaHub.php
+++ b/src/UNL/MediaHub.php
@@ -253,7 +253,7 @@ class UNL_MediaHub
 
         $metadata = json_decode($json);
         
-        if (!$metadata) {
+        if (!$metadata || !isset($metadata->streams) || !is_countable($metadata->streams)) {
             return false;
         }
 


### PR DESCRIPTION
`UNL_MediaHub::checkMetadataProjection()` determines if a video uses the 'Spherical Mapping' projection. In doing so, it attempts run a stdObject through `count()`, which results in the following error:

```
<b>Warning</b>:  count(): Parameter must be an array or an object that implements Countable in <b>/var/www/html/src/UNL/MediaHub.php</b> on line <b>261</b>
```

If warnings are displayed, this will error will be prepended to the JSON return to uploadScript.js, which will invalidate the JSON and cause the upload to fail.

Looking at the code, I believe the intent was to count the streams.