### PR TITLE
Remove title attribute from video and audio elements

### DIFF
--- a/www/templates/html/MediaPlayer/v3/Audio.tpl.php
+++ b/www/templates/html/MediaPlayer/v3/Audio.tpl.php
@@ -1,4 +1,4 @@
-<audio class="mh_player video-js vjs-default-skin" preload="auto" data-url="<?php echo $controller->getURL($context); ?>" data-mediahub-id="<?php echo (int)$context->id ?>" title="<?php echo UNL_MediaHub::escape($context->title); ?>" src="<?php echo $context->getMediaURL()?>">
+<audio class="mh_player video-js vjs-default-skin" preload="auto" data-url="<?php echo $controller->getURL($context); ?>" data-mediahub-id="<?php echo (int)$context->id ?>" src="<?php echo $context->getMediaURL()?>">
     <?php foreach ($context->getTextTrackURLs() as $lang=>$track):?>
         <track id="mediahub-track-<?php echo UNL_MediaHub::escape($lang) ?>" src="<?php echo UNL_MediaHub::escape(UNL_MediaHub_Controller::toAgnosticURL($track)) ?>" kind="captions" srclang="<?php echo UNL_MediaHub::escape($lang) ?>" />
     <?php endforeach ?>

--- a/www/templates/html/MediaPlayer/v3/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/v3/Video.tpl.php
@@ -43,7 +43,7 @@ if (isset($controller->options['captions'])) {
 }
 
 ?>
-<video  class="mh_player video-js" height="100" width="100" style="width:100%;height:100%" <?php echo $autoplay ?> <?php echo $preload ?> src="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getMediaURL()); ?>" controls data-mediahub-id="<?php echo (int)$context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getThumbnailURL()); ?>" title="<?php echo UNL_MediaHub::escape($context->title); ?>" crossorigin="anonymous" <?php echo $start_language ?>>
+<video  class="mh_player video-js" height="100" width="100" style="width:100%;height:100%" <?php echo $autoplay ?> <?php echo $preload ?> src="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getMediaURL()); ?>" controls data-mediahub-id="<?php echo (int)$context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getThumbnailURL()); ?>" crossorigin="anonymous" <?php echo $start_language ?>>
     <?php if ($context->hasHLS()): ?>
         <source src="<?php echo $context->getHLSPlaylistUrl() ?>" type="application/x-mpegURL">
     <?php endif; ?>


### PR DESCRIPTION
Currently, `<video>` and `<audio>` elements are printed with a `title` attribute. In the case of videos, when a video is enlarged to fullscreen, this causes the title to display over the video for approximately 5 seconds (in Chrome, at least)

![thumbnail_IMG_7952](https://user-images.githubusercontent.com/1521132/87698063-93dcec00-c758-11ea-85fb-e949b4baa48a.jpg)

This PR requests the `title` attribute be removed. (When I remove the attribute, WAVE does not object.)