### PR TITLE
Fix channel thumbnails

### DIFF
--- a/www/manager/templates/css/forms.css
+++ b/www/manager/templates/css/forms.css
@@ -1,4 +1,4 @@
-/* 
+/*
 -------------------------------------------------
 Supporting styles for the manager forms (add media, channel)
 -------------------------------------------------
@@ -94,15 +94,10 @@ iframe * {margin:0px}
 
 .mh-upload-box {
     width: 100%;
-    padding: 37% 0 63% 0;
     border: 2px dashed RGB(213,213,210);
     background-color: RGBA(255,255,255,.75);
     display: block;
     cursor: pointer;
-}
-
-.mh-upload-box.mh-upload-box-small {
-    padding: 20% 20px 80% 20px;
 }
 
 .mh-upload-box h2 {
@@ -156,10 +151,6 @@ iframe * {margin:0px}
 
 [class*=col-one-half] .mh-video-thumb.mh-featured-channel {
     padding: 0 0 70% 0;
-}
-
-.mh-your-channels .mh-upload-box {
-    padding: 14% 0 46% 0;
 }
 
 .mh-your-channels .mh-video-label h6{
@@ -255,8 +246,8 @@ form legend {
     background-color: white;
     content: "";
     display: block;
-    width: 15px; 
-    height: 15px; 
+    width: 15px;
+    height: 15px;
     position:absolute;
     bottom: -8px;
     left: 50%;
@@ -320,7 +311,6 @@ form legend {
 @media only screen and (max-width : 768px) {
 
     .mh-upload-band .mh-upload-box{
-        padding: 15% 0 35% 0;
         margin-bottom: 1em;
     }
 

--- a/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
+++ b/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
@@ -32,8 +32,10 @@ $page->addScript(UNL_MediaHub_Controller::getURL() . 'templates/html/scripts/upl
             <div class="dcf-grid-halves@sm dcf-col-gap-vw">
                 <div id="mh_upload_media_container">
                     <div class="dcf-ratio dcf-ratio-16x9 mh-upload-box" id="mh_upload_media">
-                        <span class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">Add Media</span>
-                        <p>.mp4 or .mp3<br>(Maximum file size: <?php echo UNL_MediaHub_Controller::$max_upload_mb; ?>mb)</p>
+                        <div class="dcf-ratio-child dcf-d-flex dcf-flex-col dcf-ai-center dcf-jc-center dcf-txt-center">
+                            <span>Add Media</span>
+                            <p class="dcf-mb-0">.mp4 or .mp3<br>(Maximum file size: <?php echo UNL_MediaHub_Controller::$max_upload_mb; ?>mb)</p>
+                        </div>
                     </div>
                     <div id="filelist" class="mh-upload-box dcf-txt-center">
                         Your browser doesn't have Flash, Silverlight or HTML5 support.

--- a/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
+++ b/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
@@ -31,8 +31,8 @@ $page->addScript(UNL_MediaHub_Controller::getURL() . 'templates/html/scripts/upl
             <input type="hidden" name="<?php echo $controller->getCSRFHelper()->getTokenValueKey() ?>" value="<?php echo $controller->getCSRFHelper()->getTokenValue() ?>">
             <div class="dcf-grid-halves@sm dcf-col-gap-vw">
                 <div id="mh_upload_media_container">
-                    <div id="mh_upload_media" class="mh-upload-box dcf-txt-center">
-                        <span class="dcf-subhead">+ Add Media</span>
+                    <div class="dcf-ratio dcf-ratio-16x9 mh-upload-box" id="mh_upload_media">
+                        <span class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">Add Media</span>
                         <p>.mp4 or .mp3<br>(Maximum file size: <?php echo UNL_MediaHub_Controller::$max_upload_mb; ?>mb)</p>
                     </div>
                     <div id="filelist" class="mh-upload-box dcf-txt-center">
@@ -115,7 +115,7 @@ $page->addScript(UNL_MediaHub_Controller::getURL() . 'templates/html/scripts/upl
                             </fieldset>
                         </div>
                     <?php endif; ?>
-                    
+
                     <input type="submit" id="publish" name="publish" value="Next Step: Add Captions" class="dcf-btn dcf-btn-primary dcf-mt-3" disabled="disabled">
                     <?php if (UNL_MediaHub_Controller::$caption_requirement_date):?>
                         <p>

--- a/www/manager/templates/html/Feed/Media/Form.tpl.php
+++ b/www/manager/templates/html/Feed/Media/Form.tpl.php
@@ -60,7 +60,7 @@ $page->jsbody .= $js;
     <input type="hidden" id="id" name="id" value="<?php echo $context->media->id ?>" />
     <input type="hidden" name="<?php echo $controller->getCSRFHelper()->getTokenNameKey() ?>" value="<?php echo $controller->getCSRFHelper()->getTokenName() ?>" />
     <input type="hidden" name="<?php echo $controller->getCSRFHelper()->getTokenValueKey() ?>" value="<?php echo $controller->getCSRFHelper()->getTokenValue() ?>">
-    
+
     <div class="dcf-bleed unl-bg-lighter-gray dcf-pt-6 dcf-bp-6">
         <div class="dcf-wrapper">
             <div class="dcf-grid" id="headline_main">
@@ -134,7 +134,7 @@ $page->jsbody .= $js;
                         <img src="<?php echo $context->media->getThumbnailURL(); ?>" id="thumbnail" alt="Thumbnail preview" />
                         <!-- <div id="poster_picker">
                             <a class="action" id="setImage" href="#">Set Image</a>
-    
+
                         </div> -->
                         <div id="poster_picker_disabled">
                             <p>
@@ -156,7 +156,7 @@ $page->jsbody .= $js;
             <?php endif; ?>
         </div>
     </div>
-    
+
     <div class="dcf-bleed dcf-pt-6 mh-edit-media">
         <div class="dcf-wrapper">
             <?php
@@ -178,10 +178,11 @@ $page->jsbody .= $js;
                                     <p><?php echo \UNL\Templates\Icons::get(\UNL\Templates\Icons::ICON_ALERT, '{"size": 4}');?><span class="dcf-sr-only">Notice:</span> You MUST use HandBrake to optimize the new video.</p>
                                 <?php endif; ?>
                                 <div id="mh_upload_media_container">
-                                    <div id="mh_upload_media" class="mh-upload-box mh-upload-box-small dcf-txt-center">
-                                        <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/swap-arrows.svg"  title="Arrow Icon">
-                                            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/swap-arrows.png" alt="browse media">
-                                        </object>
+                                    <div class="dcf-ratio dcf-ratio-16x9 mh-upload-box dcf-txt-center" id="mh_upload_media">
+                                        <img
+                                            src="<?php echo $baseUrl; ?>/templates/html/css/images/swap-arrows.svg"
+                                            aria-hidden="true"
+                                            alt="">
                                         <h2><span class="dcf-subhead">Swap Media</span></h2>
                                         <p>Upload a new .mp4 or .mp3 file and replace your old one. <strong><?php echo \UNL\Templates\Icons::get(\UNL\Templates\Icons::ICON_ALERT, '{"size": 4}');?>(Caution: This deletes your old file.)</strong></p>
                                     </div>
@@ -228,7 +229,7 @@ $page->jsbody .= $js;
                             <a class="dcf-btn dcf-btn-primary" href="<?php echo $edit_caption_url ?>">Order/Edit Captions</a>
                             <?php endif; ?>
                         </li>
-                    </ol>  
+                    </ol>
                 </div>
 
 
@@ -242,7 +243,7 @@ $page->jsbody .= $js;
                             </label>
                             <input id="title" name="title" type="text" class="required-entry" value="<?php echo UNL_MediaHub::escape(@$context->media->title); ?>" />
                         </div>
-                        
+
                         <div class="dcf-grid-halves@sm dcf-col-gap-vw">
                             <div>
                                 <div class="dcf-form-group">
@@ -260,7 +261,7 @@ $page->jsbody .= $js;
                                         <input id="mrss_copyright" name="UNL_MediaHub_Feed_Media_NamespacedElements_media[10][value]" type="text" value="<?php echo getFieldValue($context, 'media', 'copyright'); ?>"/>
                                     </div>
                                 </div>
-                            </div>           
+                            </div>
                             <div>
                                 <div class="dcf-form-group">
                                     <label for="mrss_credit">
@@ -651,7 +652,7 @@ $page->jsbody .= $js;
                         <button id="delete-media" class="dcf-btn dcf-btn-primary">Delete</button>
                     </div>
                 </div>
-                
+
                 <?php
                 function getFieldValue($savant, $xmlns, $element)
                 {

--- a/www/manager/templates/html/FeedList.tpl.php
+++ b/www/manager/templates/html/FeedList.tpl.php
@@ -19,6 +19,7 @@
                                 <?php else: ?>
                                     <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
                                         <img
+                                          class="dcf-h-8 dcf-w-8"
                                           src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
                                           height="51"
                                           width="51"

--- a/www/manager/templates/html/FeedList.tpl.php
+++ b/www/manager/templates/html/FeedList.tpl.php
@@ -8,18 +8,22 @@
                 <?php $feed_url = htmlentities(UNL_MediaHub_Controller::getURL($feed), ENT_QUOTES); ?>
                 <div>
                     <a href="<?php echo $feed_url ?>">
-                        <div class="mh-video-thumb mh-channel-thumb mh-featured-channel dcf-txt-center">
+                        <div class="mh-video-thumb mh-channel-thumb mh-featured-channel">
                             <div class="dcf-ratio dcf-ratio-16x9 mh-thumbnail-clip">
                                 <?php if($feed->hasImage()): ?>
                                     <img
-                                    class="dcf-ratio-child dcf-obj-fit-cover"
-                                    src="<?php echo $feed_url; ?>/image"
-                                    alt="<?php echo UNL_MediaHub::escape($feed->title); ?> Image">
+                                        class="dcf-ratio-child dcf-obj-fit-cover"
+                                        src="<?php echo $feed_url; ?>/image"
+                                        aria-hidden="true"
+                                        alt="">
                                 <?php else: ?>
                                     <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
-                                        <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" title="Default Channel Icon">
-                                            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon-white.png" alt="<?php echo UNL_MediaHub::escape($feed->title); ?> Image">
-                                        </object>
+                                        <img
+                                          src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
+                                          height="51"
+                                          width="51"
+                                          aria-hidden="true"
+                                          alt="">
                                     </div>
                                 <?php endif; ?>
                             </div>
@@ -33,8 +37,8 @@
                 </div>
             <?php endforeach; ?>
             <div>
-                <a class="dcf-txt-decor-none mh-upload-box dcf-txt-center" href="<?php echo UNL_MediaHub_Manager::getURL() ?>?view=feedmetadata">
-                    <span class="dcf-subhead unl-darker-gray">+ New Channel</span>
+                <a class="dcf-ratio dcf-ratio-16x9 dcf-txt-decor-none mh-upload-box" href="<?php echo UNL_MediaHub_Manager::getURL() ?>?view=feedmetadata">
+                    <span class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">Add New Channel</span>
                 </a>
             </div>
         </div>

--- a/www/templates/html/CompactFeedList.tpl.php
+++ b/www/templates/html/CompactFeedList.tpl.php
@@ -4,25 +4,32 @@ if (count($context->items)) :
 <h5><?php echo UNL_MediaHub::escape($context->label); ?></h5>
 <div class="channels">
     <?php foreach ($context->items as $channel): ?>
-    	<?php $feed_url = UNL_MediaHub_Controller::getURL($channel); ?>
-		<a href="<?php echo $feed_url ?>" title="<?php echo UNL_MediaHub::escape($channel->description); ?>">
-		    <div class="mh-channel-thumb mh-featured-channel dcf-txt-center">
-                <div>
-                    <?php if($channel->hasImage()): ?>
-                        <img
+    <?php $feed_url = UNL_MediaHub_Controller::getURL($channel); ?>
+    <a href="<?php echo $feed_url ?>" title="<?php echo UNL_MediaHub::escape($channel->description); ?>">
+        <div class="mh-channel-thumb mh-featured-channel">
+            <div class="dcf-ratio dcf-ratio-16x9 mh-thumbnail-clip">
+                <?php if($channel->hasImage()): ?>
+                    <img
+                        class="dcf-ratio-child dcf-obj-fit-cover"
                         src="<?php echo $feed_url; ?>/image"
-                        alt="<?php echo UNL_MediaHub::escape($channel->title); ?> Image">
-                    <?php else: ?>
-                        <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" title="Default Channel Icon">
-                            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon-white.png" alt="<?php echo UNL_MediaHub::escape($channel->title); ?> Image">
-                        </object>
-                    <?php endif; ?>
-                </div>
+                        aria-hidden="true"
+                        alt="">
+                <?php else: ?>
+                    <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
+                        <img
+                            src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
+                            height="51"
+                            width="51"
+                            aria-hidden="true"
+                            alt="">
+                    </div>
+                <?php endif; ?>
             </div>
-		    <div class="mh-video-label dcf-txt-center unl-font-sans">
-		                <span class="title"><?php echo UNL_MediaHub::escape($channel->title); ?></span>
-		    </div>
-		</a>
+        </div>
+        <div class="mh-video-label dcf-txt-center">
+            <span class="title"><?php echo UNL_MediaHub::escape($channel->title); ?></span>
+        </div>
+    </a>
     <?php endforeach; ?>
 </div>
 <?php endif; ?>

--- a/www/templates/html/CompactFeedList.tpl.php
+++ b/www/templates/html/CompactFeedList.tpl.php
@@ -17,6 +17,7 @@ if (count($context->items)) :
                 <?php else: ?>
                     <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
                         <img
+                            class="dcf-h-8 dcf-w-8"
                             src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
                             height="51"
                             width="51"

--- a/www/templates/html/DefaultHomepage.tpl.php
+++ b/www/templates/html/DefaultHomepage.tpl.php
@@ -39,9 +39,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     <div class="mh-featured">
       <a class="dcf-d-flex dcf-flex-col dcf-ai-center dcf-txt-decor-hover" href="<?php echo $baseUrl ?>search/">
         <div class="mh-featured-icon mh-green dcf-d-flex dcf-ai-center dcf-jc-center dcf-h-10 dcf-w-10 dcf-circle">
-          <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/play-icon.svg"  title="Play Icon">
-            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/play-icon-white.png" alt="browse media">
-          </object>
+          <img src="<?php echo $baseUrl; ?>/templates/html/css/images/play-icon.svg" aria-hidden="true" alt="">
         </div>
         <h2 class="dcf-mt-2 dcf-txt-h4">Browse Media</h2>
       </a>
@@ -50,9 +48,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     <div class="mh-featured">
       <a class="dcf-d-flex dcf-flex-col dcf-ai-center dcf-txt-decor-hover" href="<?php echo $baseUrl ?>channels/">
         <div class="mh-featured-icon mh-blue dcf-d-flex dcf-ai-center dcf-jc-center dcf-h-10 dcf-w-10 dcf-circle">
-          <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" title="Default Channel Icon">
-            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon-white.png" alt="explore channels">
-          </object>
+          <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" aria-hidden="true" alt="">
         </div>
         <h2 class="dcf-mt-2 dcf-txt-h4">Explore Channels</h2>
       </a>
@@ -61,9 +57,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     <div class="mh-featured">
       <a class="dcf-d-flex dcf-flex-col dcf-ai-center dcf-txt-decor-hover" href="<?php echo $baseUrl ?>manager/">
         <div class="mh-featured-icon dcf-d-flex dcf-ai-center dcf-jc-center dcf-h-10 dcf-w-10 dcf-circle unl-bg-scarlet">
-          <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/gear-icon.svg"  title="Manage Media Icon">
-            <img src="<?php echo $baseUrl; ?>/templates/html/css/images/gear-icon-white.png" alt="manage media">
-          </object>
+          <img src="<?php echo $baseUrl; ?>/templates/html/css/images/gear-icon.svg" aria-hidden="true" alt="">
         </div>
         <h2 class="dcf-mt-2 dcf-txt-h4">Manage Media</h2>
       </a>

--- a/www/templates/html/FeedAndMedia.tpl.php
+++ b/www/templates/html/FeedAndMedia.tpl.php
@@ -29,6 +29,7 @@ $user = UNL_MediaHub_AuthService::getInstance()->getUser();
               <?php else: ?>
                 <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
                     <img
+                        class="dcf-h-8 dcf-w-8"
                         src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
                         height="51"
                         width="51"

--- a/www/templates/html/FeedAndMedia.tpl.php
+++ b/www/templates/html/FeedAndMedia.tpl.php
@@ -18,16 +18,22 @@ $user = UNL_MediaHub_AuthService::getInstance()->getUser();
 
       <div class="dcf-grid dcf-col-gap-vw dcf-pt-6">
         <div class="dcf-col-100% dcf-col-25%-start@sm">
-          <div class="mh-channel-thumb dcf-txt-center">
+          <div class="dcf-ratio dcf-ratio-16x9 mh-channel-thumb">
               <?php $url = htmlentities(UNL_MediaHub_Controller::getURL($context->feed), ENT_QUOTES) ?>
               <?php if($context->feed->hasImage()): ?>
-                <img src="<?php echo $url; ?>/image"
-                    alt="<?php echo UNL_MediaHub::escape($context->feed->title); ?> Image">
+                <img
+                    class="dcf-ratio-child dcf-obj-fit-cover"
+                    src="<?php echo $url; ?>/image"
+                    aria-hidden="true"
+                    alt="">
               <?php else: ?>
-                <div>
-                  <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" title="Default Channel Icon">
-                    <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon-white.png" alt="<?php echo htmlentities($context->feed->title, ENT_QUOTES); ?> Image">
-                  </object>
+                <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
+                    <img
+                        src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
+                        height="51"
+                        width="51"
+                        aria-hidden="true"
+                        alt="">
                 </div>
               <?php endif; ?>
           </div>

--- a/www/templates/html/FeedList.tpl.php
+++ b/www/templates/html/FeedList.tpl.php
@@ -99,6 +99,7 @@ if($context->options['orderby'] == 'datecreated'){
                                         <?php else: ?>
                                             <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
                                                 <img
+                                                    class="dcf-h-8 dcf-w-8"
                                                     src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
                                                     height="51"
                                                     width="51"

--- a/www/templates/html/FeedList.tpl.php
+++ b/www/templates/html/FeedList.tpl.php
@@ -13,7 +13,7 @@ if (isset($context->label) && !empty($context->label)) {
 ?>
 
 
-<?php 
+<?php
 
 if($context->options['orderby'] == 'datecreated'){
 
@@ -76,7 +76,7 @@ if($context->options['orderby'] == 'datecreated'){
     <div class="dcf-wrapper dcf-pt-8 dcf-pb-8">
         <div class="mh-feeds">
             <?php if (count($context->items)): ?>
-                <?php 
+                <?php
                 $pager_layout = new UNL_MediaHub_List_PagerLayout($context->pager,
                     new Doctrine_Pager_Range_Sliding(array('chunk'=>5)),
                     htmlentities(UNL_MediaHub_Controller::getURL($context, array_merge($context->options, array('page'=>'{%page_number}')))));
@@ -89,16 +89,21 @@ if($context->options['orderby'] == 'datecreated'){
                             <div class="dcf-grid dcf-col-gap-vw">
                                 <div class="dcf-col-100% dcf-col-25%-start@sm">
                                     <a href="<?php echo $url ?>">
-                                    <div class="mh-channel-thumb dcf-txt-center">
+                                    <div class="dcf-ratio dcf-ratio-16x9 mh-channel-thumb">
                                         <?php if($feed->hasImage()): ?>
                                             <img
-                                            src="<?php echo $url; ?>/image"
-                                            alt="<?php echo UNL_MediaHub::escape($feed->title); ?> Image">
+                                                class="dcf-ratio-child dcf-obj-fit-cover"
+                                                src="<?php echo $url; ?>/image"
+                                                aria-hidden="true"
+                                                alt="">
                                         <?php else: ?>
-                                            <div>
-                                                <object type="image/svg+xml" data="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg" title="Default Channel Icon">
-                                                    <img src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon-white.png" alt="<?php echo UNL_MediaHub::escape($feed->title); ?> Image">
-                                                </object>
+                                            <div class="dcf-ratio-child dcf-d-flex dcf-ai-center dcf-jc-center">
+                                                <img
+                                                    src="<?php echo $baseUrl; ?>/templates/html/css/images/channel-icon.svg"
+                                                    height="51"
+                                                    width="51"
+                                                    aria-hidden="true"
+                                                    alt="">
                                             </div>
                                         <?php endif; ?>
                                     </div>


### PR DESCRIPTION
- Remove `<object>` element and use SVG images instead for default channel icon
- Hide channel thumbnail images from screen readers as they are presentational
- Remove redundant `unl-font-sans` class
- Remove UNL-specific color class
- Remove padding from `.mh-upload-box` and use DCF ratio and flexbox classes instead
- Fix file upload boxes to also use DCF ratio and flexboxes
- Change “+ New Channel” and "+ Add Media" to “Add New Channel” and "Add Media"
- Fix indents