### PR TITLE
Tweak homepage popular media display and logic

### DIFF
--- a/scripts/mediaViews.php
+++ b/scripts/mediaViews.php
@@ -15,7 +15,7 @@ $sql = "DELETE FROM media_views WHERE datecreated < (NOW() - INTERVAL 1 MONTH)";
 $q   = $db->prepare($sql);
 $q->execute();
 
-//Update popular counts (more of a weight than an acutal count)
+//Update popular counts (more of a weight than an actual count)
 $sql = "
 UPDATE media
 INNER JOIN (

--- a/scripts/mediaViews.php
+++ b/scripts/mediaViews.php
@@ -15,7 +15,12 @@ $sql = "DELETE FROM media_views WHERE datecreated < (NOW() - INTERVAL 1 MONTH)";
 $q   = $db->prepare($sql);
 $q->execute();
 
-//Update popular counts (more of a weight than an actual count)
+//Update all popular counts (more of a weight than an actual count)
+$sql = "UPDATE media SET popular_play_count = round(media.play_count*.15)";
+$q   = $db->prepare($sql);
+$q->execute();
+
+//Update popular counts (more of a weight than an actual count) with views in last month
 $sql = "
 UPDATE media
 INNER JOIN (

--- a/src/Themes/default/homepage.tpl.php
+++ b/src/Themes/default/homepage.tpl.php
@@ -25,7 +25,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     if (count($topMedia) > 0):
 ?>
 <div class="dcf-bleed dcf-wrapper dcf-pt-7 dcf-pb-8 unl-bg-lightest-gray">
-    <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Popular Videos</h2>
+    <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media<br><span class="dcf-txt-2xs">Added in the last two weeks</span></h2>
     <div class="dcf-grid-halves@sm dcf-grid-thirds@md dcf-col-gap-vw dcf-row-gap-7">
     <?php foreach ($context->getTopMedia() as $media): ?>
         <div>

--- a/src/Themes/default/homepage.tpl.php
+++ b/src/Themes/default/homepage.tpl.php
@@ -25,7 +25,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     if (count($topMedia) > 0):
 ?>
 <div class="dcf-bleed dcf-wrapper dcf-pt-7 dcf-pb-8 unl-bg-lightest-gray">
-    <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media<br><span class="dcf-txt-2xs">Added in the last two weeks</span></h2>
+    <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media</span></h2>
     <div class="dcf-grid-halves@sm dcf-grid-thirds@md dcf-col-gap-vw dcf-row-gap-7">
     <?php foreach ($context->getTopMedia() as $media): ?>
         <div>

--- a/src/Themes/unl/homepage.tpl.php
+++ b/src/Themes/unl/homepage.tpl.php
@@ -25,7 +25,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     if (count($topMedia) > 0):
 ?>
     <div class="dcf-bleed dcf-wrapper dcf-pt-7 dcf-pb-8 unl-bg-lightest-gray">
-        <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Popular Videos</h2>
+        <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media<br><span class="dcf-txt-2xs">Added in the last two weeks</span></h2>
         <div class="dcf-grid-halves@sm dcf-grid-thirds@md dcf-col-gap-vw dcf-row-gap-7">
         <?php foreach ($context->getTopMedia() as $media): ?>
             <div>

--- a/src/Themes/unl/homepage.tpl.php
+++ b/src/Themes/unl/homepage.tpl.php
@@ -25,7 +25,7 @@ $baseUrl = UNL_MediaHub_Controller::getURL();
     if (count($topMedia) > 0):
 ?>
     <div class="dcf-bleed dcf-wrapper dcf-pt-7 dcf-pb-8 unl-bg-lightest-gray">
-        <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media<br><span class="dcf-txt-2xs">Added in the last two weeks</span></h2>
+        <h2 class="dcf-txt-center dcf-subhead dcf-mb-6">Recent Popular Media</h2>
         <div class="dcf-grid-halves@sm dcf-grid-thirds@md dcf-col-gap-vw dcf-row-gap-7">
         <?php foreach ($context->getTopMedia() as $media): ?>
             <div>

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -39,7 +39,7 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
         $top_media = new UNL_MediaHub_MediaList($options);
         $top_media->run();
 
-        $after_date = strtotime('2 weeks ago');
+        $after_date = strtotime('1 month ago');
 
         $limit = 6;
         $found_channels = array();

--- a/src/UNL/MediaHub/DefaultHomepage.php
+++ b/src/UNL/MediaHub/DefaultHomepage.php
@@ -39,9 +39,8 @@ class UNL_MediaHub_DefaultHomepage implements UNL_MediaHub_CacheableInterface
         $top_media = new UNL_MediaHub_MediaList($options);
         $top_media->run();
 
-        $after_date = strtotime('6 months ago');
-        
-        //return $top_media->items;
+        $after_date = strtotime('2 weeks ago');
+
         $limit = 6;
         $found_channels = array();
         $media_list = array();

--- a/www/manager/templates/html/Manager.tpl.php
+++ b/www/manager/templates/html/Manager.tpl.php
@@ -16,7 +16,7 @@ if (!$theme->isCustomTheme()) {
         $page->setLocalIncludePath($theme->getWDNIncludePath());
     }
     // Add WDN Deprecated Styles
-    $page->head .= '<link rel="preload" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css" as="style" onload="this.onload=null;this.rel=\'stylesheet\'"> <noscript><link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css"></noscript>';
+    $page->head .= '<link rel="preload" href="../wdn/templates_5.3/css/deprecated.css" as="style" onload="this.onload=null;this.rel=\'stylesheet\'"> <noscript><link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css"></noscript>';
 
     $page->contactinfo = $theme->renderThemeTemplate(null, 'localfooter.tpl.php');
 

--- a/www/templates/html/Controller.tpl.php
+++ b/www/templates/html/Controller.tpl.php
@@ -20,7 +20,7 @@ if (!$theme->isCustomTheme()) {
     }
 
     // Add WDN Deprecated Styles
-    $page->head .= '<link rel="preload" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css" as="style" onload="this.onload=null;this.rel=\'stylesheet\'"> <noscript><link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css"></noscript>';
+    $page->head .= '<link rel="preload" href="wdn/templates_5.3/css/deprecated.css" as="style" onload="this.onload=null;this.rel=\'stylesheet\'"> <noscript><link rel="stylesheet" href="https://unlcms.unl.edu/wdn/templates_5.3/css/deprecated.css"></noscript>';
 
     $page->contactinfo = $theme->renderThemeTemplate(null, 'localfooter.tpl.php');
 


### PR DESCRIPTION
Can test on https://mediahub-test.unl.edu/.

Caveats with current implementation:
* Only media created in the last month will be included in top media.
* Only media with a feed/channel are eligible.
* Only one media of a feed/channel are eligible.  The highest media of of channel will be included and any other media will be ignored.
* The popular play count metric gets updated every fifteen minutes but due to caching (on production) the homepage list will only update daily from last time cached. Logic to update popular play count https://github.com/unl/UNL_MediaHub/blob/master/scripts/mediaViews.php.   **Updated to set popular_play_count to play_count * .15 to treat all media the same on each update based on views in last month.**  Then will re-update any that have been viewed in the last month.

Note: I updated the created date of all the media to May 13th in the test DB to get media to display.
 