### PR TITLE
Implement query string start time (t) for video and audio media

### DIFF
--- a/www/templates/html/Media.tpl.php
+++ b/www/templates/html/Media.tpl.php
@@ -11,6 +11,13 @@ if ($context->isVideo()) {
     }
 }
 
+// Set start time param (t) if valid in query string for media iframe URL
+$time = 0;
+if (!empty($_GET['t'])) {
+    $time = filter_input(INPUT_GET, 't', FILTER_VALIDATE_FLOAT);
+}
+$timeParam = !empty($time) ? '&t=' . $time : '';
+
 $user = UNL_MediaHub_AuthService::getInstance()->getUser();
 
 $context->loadReference('UNL_MediaHub_Media_Comment');
@@ -58,7 +65,7 @@ if ($type === 'audio') {
 <div class="dcf-bleed mh-video-band">
     <div class="dcf-wrapper dcf-pt-4 dcf-pb-4 dcf-d-flex dcf-jc-center">
         <div class="<?php echo $divClass; ?>">
-            <iframe class="<?php echo $iframeClass; ?>" height="667" src="<?php echo $controller->getURL($context)?>?format=iframe&autoplay=0&preload=auto" allowfullscreen title="play media"></iframe>
+            <iframe class="<?php echo $iframeClass; ?>" height="667" src="<?php echo $controller->getURL($context)?>?format=iframe&autoplay=0&preload=auto<?php echo $timeParam; ?>" allowfullscreen title="play media"></iframe>
         </div>
     </div>
 </div>

--- a/www/templates/html/MediaPlayer/v3/Video.tpl.php
+++ b/www/templates/html/MediaPlayer/v3/Video.tpl.php
@@ -43,7 +43,7 @@ if (isset($controller->options['captions'])) {
 }
 
 ?>
-<video  class="mh_player video-js" height="100" width="100" style="width:100%;height:100%" <?php echo $autoplay ?> <?php echo $preload ?> src="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getMediaURL()); ?>" controls data-mediahub-id="<?php echo (int)$context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getThumbnailURL()); ?>" title="<?php echo UNL_MediaHub::escape($context->title); ?>" <?php echo $start_language ?>>
+<video class="mh_player video-js" height="100" width="100" style="width:100%;height:100%" <?php echo $autoplay ?> <?php echo $preload ?> src="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getMediaURL()); ?>" controls data-mediahub-id="<?php echo (int)$context->id ?>" data-url="<?php echo $controller->getURL($context); ?>" poster="<?php echo UNL_MediaHub_Controller::toAgnosticURL($context->getThumbnailURL()); ?>" title="<?php echo UNL_MediaHub::escape($context->title); ?>" <?php echo $start_language ?>>
     <?php if ($context->hasHLS()): ?>
         <source src="<?php echo $context->getHLSPlaylistUrl() ?>" type="application/x-mpegURL">
     <?php endif; ?>

--- a/www/templates/html/MediaPlayer/v3/player.tpl.php
+++ b/www/templates/html/MediaPlayer/v3/player.tpl.php
@@ -94,6 +94,29 @@
                         });
                     });
 
+                    //Set starttime if valid
+                    player.on('loadedmetadata', function() {
+                        try {
+                            const queryString = $media.get(0).baseURI;
+                            const urlParams = new URLSearchParams(queryString);
+                            const startTime = parseFloat(urlParams.get('t'));
+                            if (startTime && !isNaN(startTime)) {
+                                if (videoElement.tagName === 'AUDIO') {
+                                    const audioPlayer = player.wavesurfer().surfer;
+                                    audioPlayer.on('ready', function(event) {
+                                        if (startTime < audioPlayer.getDuration()) {
+                                            audioPlayer.skipForward(startTime);
+                                        }
+                                    });
+                                } else if (startTime < player.duration()) {
+                                    player.currentTime(startTime);
+                                }
+                            }
+                       } catch(e) {
+                            // do nothing
+                       }
+                    });
+
                     if (videoElement.tagName === 'AUDIO') {
                         //Show loading indicator while loading the audio file
                         player.addClass('vjs-waiting');


### PR DESCRIPTION
Verify works for audio and video for both mediahub site and embed.

The query string param `t` will specify where media starts `t` is in seconds and may be an integer or float and must not be longer than media duration.

Can test on mediahub-test:

Video Example
* Direct: https://mediahub-test.unl.edu/media/30?t=45.6667
* Embed: 
```
<div style="padding-top: 56.25%; overflow: hidden; position:relative; -webkit-box-flex: 1; flex-grow: 1;">
    <iframe style="bottom: 0; left: 0; position: absolute; right: 0; top: 0; border: 0; height: 100%; width: 100%;" src="https://mediahub-test.unl.edu/media/30?format=iframe&autoplay=0&t=30.5" title="Video Player:  HLS test" allowfullscreen></iframe>
</div>
```

Audio Example
* Direct: https://mediahub-test.unl.edu/media/51?t=100
* Embed: 
```
<div style="height: 5.62em; max-width: 56.12rem; overflow: hidden; position:relative; -webkit-box-flex: 1; flex-grow: 1;">
    <iframe style="bottom: 0; left: 0; position: absolute; right: 0; top: 0; border: 0; height: 100%; width: 100%;" src="https://mediahub-test.unl.edu/media/51?format=iframe&autoplay=0&t=45.75" title="Audio Player:  Test MP3" allowfullscreen></iframe>
</div>
```
