### PR TITLE
Add media.last_played tracking

### DIFF
--- a/data/add_last_played.sql
+++ b/data/add_last_played.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `media` ADD `last_played` TIMESTAMP NULL AFTER `popular_play_count`;
+-- ALTER TABLE `media` DROP `last_played`;

--- a/scripts/findBrokenMedia.php
+++ b/scripts/findBrokenMedia.php
@@ -1,7 +1,7 @@
 <?php
 require_once dirname(__FILE__).'/../config.inc.php';
 
-//ini_set('display_errors', true);
+ini_set('display_errors', true);
 
 $mediahub = new UNL_MediaHub();
 

--- a/scripts/findBrokenMedia.php
+++ b/scripts/findBrokenMedia.php
@@ -1,8 +1,6 @@
 <?php
 require_once dirname(__FILE__).'/../config.inc.php';
 
-ini_set('display_errors', true);
-
 $mediahub = new UNL_MediaHub();
 
 $list = new UNL_MediaHub_MediaList(array('limit'=>99999));

--- a/scripts/findBrokenMedia.php
+++ b/scripts/findBrokenMedia.php
@@ -1,0 +1,31 @@
+<?php
+require_once dirname(__FILE__).'/../config.inc.php';
+
+//ini_set('display_errors', true);
+
+$mediahub = new UNL_MediaHub();
+
+$list = new UNL_MediaHub_MediaList(array('limit'=>99999));
+$list->run();
+
+if (!count($list->items)) {
+	echo 'no records found' . PHP_EOL;
+	exit();
+}
+
+foreach ($list->items as $media) {
+
+	// Try and get the media
+	$agnostic_file_url = preg_replace('/^https?:\/\//', '//', $media->url, 1);
+	$agnostic_uploads_url = preg_replace('/^https?:\/\//', '//', UNL_MediaHub_Controller::getURL() . 'uploads/', 1);
+
+	if (strpos($agnostic_file_url, $agnostic_uploads_url) !== 0) {
+		//not local media
+		continue;
+	}
+
+	if (!$media->getLocalFileName()) {
+		echo $media->id . ' is broken ' . PHP_EOL;
+		echo "\t" . $media->url . PHP_EOL;
+	}
+}

--- a/src/UNL/MediaHub/MediaView.php
+++ b/src/UNL/MediaHub/MediaView.php
@@ -18,6 +18,7 @@ class UNL_MediaHub_MediaView extends UNL_MediaHub_Models_BaseMediaView
 
         //Update the media play count
         $media->play_count++;
+        $media->last_played = date('Y-m-d H:i:s');
         $media->save();
         
         return $view;

--- a/src/UNL/MediaHub/Models/BaseMedia.php
+++ b/src/UNL/MediaHub/Models/BaseMedia.php
@@ -21,6 +21,7 @@ abstract class UNL_MediaHub_Models_BaseMedia extends Doctrine_Record
         $this->hasColumn('privacy',       'enum',      null, array('primary' => false, 'notnull' => true, 'autoincrement' => false, 'values' => array('PUBLIC', 'UNLISTED', 'PROTECTED', 'PRIVATE'), 'default' => 'PUBLIC'));
         $this->hasColumn('play_count',    'integer',   null, array('unsigned' => 0, 'primary' => false, 'notnull' => true, 'autoincrement' => true));
         $this->hasColumn('popular_play_count', 'integer',   null, array('unsigned' => 0, 'primary' => false, 'notnull' => true, 'autoincrement' => false));
+        $this->hasColumn('last_played',   'timestamp', null, array('primary' => false, 'notnull' => false, 'autoincrement' => false));
         $this->hasColumn('datecreated',   'timestamp', null, array('primary' => false, 'notnull' => true, 'autoincrement' => false));
         $this->hasColumn('dateupdated',   'timestamp', null, array('primary' => false, 'notnull' => false, 'autoincrement' => false));
         $this->hasColumn('media_text_tracks_id', 'integer', null, array('primary' => false, 'notnull' => false, 'autoincrement' => false));


### PR DESCRIPTION
Adds tracking for last time media was played for future use to help determine candidates for purging media.  There is a media_views table but it only tracks views within the last month.

Also added `scripts/findBrokenMedia.php` which I copied from production server to find broken media.  This script can be updated to delete these media if desired.
