### PR TITLE
Replace load with currentTime 0

### DIFF
--- a/www/templates/iframe/Controller.tpl.php
+++ b/www/templates/iframe/Controller.tpl.php
@@ -56,7 +56,7 @@ if (isset($context->output[0]) && $context->output[0] instanceof UNL_MediaHub_Me
                 break;
               case 'mh-reset-video':
                 video.pause();
-                video.load();
+                video.currentTime = 0;
                 break;
               case 'mh-pause-video':
                 video.pause();


### PR DESCRIPTION
`video.load()` was causing the video to error out due to videojs removing the sources from the video. So when `mh-reset-video` was being called it would error out the video and make it unplayable. What we actually want is `video.currentTime=0` which will reset the video back to the beginning.