### PR TITLE
Added a page for unreviewed AI-generated media captions. Fixes #518.

### DIFF
--- a/data/routes.php
+++ b/data/routes.php
@@ -15,6 +15,8 @@ $routes['/^transcode-manager\/command\/?$/'] = 'UNL_MediaHub_TranscodeManager';
 
 $routes['/^transcription-manager\/?$/'] = 'UNL_MediaHub_TranscriptionManager';
 
+$routes['/^caption-review-list-manager\/?$/'] = 'UNL_MediaHub_CaptionReviewListManager';
+
 $routes['/^search\/(?P<q>.*)$/'] = 'UNL_MediaHub_MediaList';
 
 $routes['/^tags\/(?P<t>.*)$/'] = 'UNL_MediaHub_MediaList';

--- a/src/UNL/MediaHub/CaptionReviewListManager.php
+++ b/src/UNL/MediaHub/CaptionReviewListManager.php
@@ -1,0 +1,33 @@
+<?php
+class UNL_MediaHub_CaptionReviewListManager {
+    public $options = array();
+    public $unreviewedMediaCaptionList;
+    public $items = array();
+    private $auth;
+    private $user;
+    public function __construct($options = array()) {
+        $this->options = $options;
+        $this->auth = UNL_MediaHub_AuthService::getInstance();
+        $this->auth->login();
+        $this->user = $this->auth->getUser();
+        $this->unreviewedMediaCaptionList  = UNL_MediaHub_User::getMediaWithUnreviewedCaptions($this->user);
+        $this->user = $this->auth->getUser();
+    }
+
+
+    public static function getURL() {
+        return UNL_MediaHub_Controller::$url . "caption-review-list-manager";
+    }
+
+    public static function getJSONURL() {
+        return UNL_MediaHub_Controller::$url . "caption-review-list-manager/?format=json";
+    }
+
+    public function hasUnreviewedCaptionMedia() {
+        return count($this->unreviewedMediaCaptionList->items) > 0;
+    }
+
+    public function getUnreviewedCaptionMedia() {
+        return $this->unreviewedMediaCaptionList->items;
+    }
+}

--- a/src/UNL/MediaHub/Controller.php
+++ b/src/UNL/MediaHub/Controller.php
@@ -714,6 +714,16 @@ class UNL_MediaHub_Controller
         if (isset($siteNotice) && $siteNotice->display) {
             $page->displayDCFNoticeMessage($siteNotice->title, $siteNotice->message, $siteNotice->type, $siteNotice->noticePath, $siteNotice->containerID);
         }
+        // Add a notice for logged users with:
+        // Active AI captions that have not been reviewed OR
+        // Videos that currently have no active captions but contain AI-generated captions that could be activated after review.
+        $auth = UNL_MediaHub_AuthService::getInstance();
+        if($auth->isLoggedIn()) {
+            if(count(UNL_MediaHub_User::getMediaWithUnreviewedCaptions($auth->getUser())->items) > 0) {
+            $page->displayDCFNoticeMessage('You have unreviewed media captions', "Please review auto generated AI captions for your media for any missed context or inaccuracies. <a href=\"" . htmlspecialchars(UNL_MediaHub_CaptionReviewListManager::getURL()) . "\">View Unreviewed Media Captions.</a>", 'dcf-notice-warning', $siteNotice->noticePath, $siteNotice->containerID);
+            }
+        }
+        
     }
 
     /**

--- a/src/UNL/MediaHub/MediaList/Filter/UnreviewedCaptions.php
+++ b/src/UNL/MediaHub/MediaList/Filter/UnreviewedCaptions.php
@@ -1,0 +1,45 @@
+<?php
+class UNL_MediaHub_MediaList_Filter_UnreviewedCaptions implements UNL_MediaHub_Filter
+{
+    protected $query;
+    protected $user;
+
+    public function __construct(UNL_MediaHub_User $user)
+    {
+        $this->user = $user;
+    }
+    
+    public function apply(Doctrine_Query_Abstract $query)
+    {
+      $query->addFrom('LEFT JOIN mediahub.media_text_tracks mtt ON (mtt.media_id = m.id)');
+      $query->addFrom('JOIN mediahub.feed_has_media fhm ON (fhm.media_id = m.id)');
+      $query->addFrom('JOIN mediahub.user_has_permission uhm ON (uhm.feed_id = fhm.feed_id)');
+      $query->where('(m.media_text_tracks_id IS NULL and mtt.source = "ai transcriptionist" and permission_id = 2) OR (mtt.source = "ai transcriptionist" and uhm.user_uid = ? and uhm.feed_id = fhm.feed_id and m.media_text_tracks_id IS NOT NULL and media_text_tracks_source_id is null and m.media_text_tracks_id = mtt.id and permission_id = 2)', $this->user->uid);
+      $query->groupBy('m.id');
+    }
+    
+    public function getLabel()
+    {
+        return 'UnreviewedCaptions';
+    }
+    
+    public function getType()
+    {
+        return 'UnreviewedCaptions';
+    }
+    
+    public function getValue()
+    {
+        return $this->query;
+    }
+    
+    public function __toString()
+    {
+        return '';
+    }
+
+    public static function getDescription()
+    {
+        return 'List of all media that either have an active AI caption that has not been reviewed or have a generated AI caption that is not yet activated and is pending review.';
+    }
+}

--- a/src/UNL/MediaHub/User.php
+++ b/src/UNL/MediaHub/User.php
@@ -50,6 +50,17 @@ class UNL_MediaHub_User extends UNL_MediaHub_Models_BaseUser
     }
 
     /**
+     * Returns a list of media with unreviewed AI-generated captions.
+     * 
+     * @return UNL_MediaHub_MediaList
+     */
+    public static function getMediaWithUnreviewedCaptions($uid)
+    {
+       $options['filter'] = new UNL_MediaHub_MediaList_Filter_UnreviewedCaptions($uid);
+       return new UNL_MediaHub_MediaList($options);
+    }
+
+    /**
      * Get an array of feed IDs
      * 
      * @return mixed
@@ -66,7 +77,7 @@ class UNL_MediaHub_User extends UNL_MediaHub_Models_BaseUser
         $result = $q->fetchAll(PDO::FETCH_COLUMN);
         return $result;
     }
-    
+
     public function canTranscode()
     {
         return UNL_MediaHub::$auto_transcode_hls_all_users;

--- a/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
+++ b/www/manager/templates/html/Feed/Media/FileUpload.tpl.php
@@ -180,20 +180,23 @@ $page->addScript(UNL_MediaHub_Controller::getURL() . 'templates/html/scripts/upl
 
                     <fieldset>
                         <legend>AI Captions</legend>
-                        <div class="dcf-input-checkbox">
+                        <div class="dcf-input-checkbox dcf-pb-3">
                             <input id="opt-out-captions" name="opt-out-captions" aria-describedby="opt-out-captions-help" type="checkbox" value="1">
                             <label for="opt-out-captions">Opt Out of AI captions</label>
                             <p class="dcf-form-help dcf-mb-0" id="opt-out-captions-help">
-                                Captions are free to generate and will automatically
-                                be translated into English. You would only want to
-                                check this if you have your own captions.
+                                Captions are required for all media uploads.
+                                Only select this option if you are providing your own captions.
                             </p>
                         </div>
 
-                        <!-- <div class="dcf-input-checkbox">
+                             <div class="dcf-input-checkbox">
                             <input id="auto-activate-captions" name="auto-activate-captions" type="checkbox" value="1" checked="checked">
                             <label for="auto-activate-captions">Auto activate captions after generation</label>
-                        </div> -->
+                            <p class="dcf-form-help dcf-mb-0" id="opt-out-captions-help">
+                                Captions are free to generate and will automatically
+                                be translated into English.
+                            </p>
+                        </div> 
                     </fieldset>
                     <p class="dcf-txt-sm">
                         Note: All videos will be optimized for web in multiple resolutions automatically.

--- a/www/manager/templates/html/Media/EditCaptions.tpl.php
+++ b/www/manager/templates/html/Media/EditCaptions.tpl.php
@@ -97,21 +97,33 @@
                             </td>
                             <td data-label="Actions" class="dcf-txt-sm">
                                 <?php if($is_ai_gen && !$is_copy): ?>
-                                    <div class="dcf-d-flex dcf-flex-row dcf-flex-wrap dcf-jc-start dcf-ai-center dcf-gap-3">
-                                        <a
-                                            href="<?php
-                                                echo UNL_MediaHub_Manager::getURL()
-                                                    . '?view=editcaptiontrack&media_id='
-                                                    . (int)$context->media->id
-                                                    . '&track_id='
-                                                    . (int)$track->id;
-                                                ?>"
-                                            class="dcf-btn dcf-btn-primary dcf-mt-1"
-                                        >
-                                            Review
-                                        </a>
-                                        <p class="dcf-m-0 dcf-p-0 dcf-txt-xs">Captions need to be reviewed before activation</p>
+                                    <div class="dcf-grid dcf-row-gap-2 dcf-col-gap-3 dcf-ai-center">
+                                        <div class="dcf-col-100% dcf-col-75%-start@md">
+                                            <a
+                                                href="<?php
+                                                    echo UNL_MediaHub_Manager::getURL()
+                                                        . '?view=editcaptiontrack&media_id='
+                                                        . (int)$context->media->id
+                                                        . '&track_id='
+                                                        . (int)$track->id;
+                                                    ?>"
+                                                class="dcf-btn dcf-btn-primary dcf-mt-1"
+                                                >
+                                                Review
+                                            </a>
+                                        </div>
+                                        <?php $active_check = $is_active ? 'checked="checked"' : ''; ?>
+                                        <div  class="dcf-input-radio dcf-col-100% dcf-col-25%-end@md">
+                                            <input disabled id="caption-active-radio-<?php echo (int) $track->id; ?>" form="caption_active_form"
+                                                name="text_track_id" type="radio" value="<?php echo (int) $track->id; ?>" <?php echo $active_check; ?>>
+                                            <label for="caption-active-radio-<?php echo (int) $track->id; ?>">Active</label>
+                                        </div>
                                     </div>
+                                    <?php if($is_active): ?> 
+                                    <p class="dcf-m-0 dcf-pt-4 dcf-txt-xs">Captions need to be reviewed</p>
+                                    <?php else: ?>
+                                        <p class="dcf-m-0 dcf-pt-4 dcf-txt-xs">Captions need to be reviewed before activation</p>
+                                    <?php endif; ?>
                                 <?php else: ?>
                                     <div class="dcf-grid dcf-row-gap-3 dcf-col-gap-3 dcf-ai-center">
                                         <div class="dcf-col-100% dcf-col-75%-start@md">

--- a/www/templates/html/CaptionReviewListManager.tpl.php
+++ b/www/templates/html/CaptionReviewListManager.tpl.php
@@ -1,0 +1,59 @@
+<div class="dcf-bleed dcf-pt-6 dcf-mb-6">
+    <div class="dcf-wrapper">
+        <h2 class="dcf-txt-h2">Unreviewed Media Captions List</h2>
+        <p> Captions for audio content are required for ADA compliance. Please review the list of media items that either have active AI-generated captions that have not been reviewed, or have generated captions pending activation and review. Ensure all AI-generated captions are reviewed for accuracy and context. You can also upload your own captions. </p>
+
+        <div class="dcf-grid dcf-col-gap-vw dcf-row-gap-4">
+            <div class="dcf-col-100%">
+                <?php if ($context->hasUnreviewedCaptionMedia()) { ?>
+                    <h3 class="dcf-txt-h6" id="table-description">List of all media that either have an active AI caption that has not been reviewed or have a generated AI caption that is not yet activated and is pending review. </h3>
+                    <table class="dcf-table dcf-table-bordered dcf-table-responsive" aria-describedby="table-description">
+                        <thead>
+                            <th scope="col">Media</th>
+                            <th scope="col">Type</th>
+                            <th scope="col">Date Uploaded</th>
+                            <th scope="col">Uploaded By</th>
+                            <th scope="col">Associated Channels</th>
+                            <th scope="col">Actions</th>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <?php foreach ($context->getUnreviewedCaptionMedia() as $media): ?>
+                                    <td class="dcf-txt-right" data-label="Title">
+                                        <a href="<?php echo $media->getURL(); ?>">
+                                            <?php echo htmlspecialchars($media['title']); ?>
+                                        </a>
+                                    </td>
+                                    <td class="dcf-txt-right" data-label="Type"><?php echo htmlspecialchars($media['type']); ?></td>
+                                    <td class="dcf-txt-right" data-label="Date"><?php echo htmlspecialchars($media['datecreated']); ?></td>
+                                    <td class="dcf-txt-right" data-label="Username"><?php echo htmlspecialchars($media['uidcreated']); ?></td>
+                                    <td class="dcf-txt-right" data-label="Channels">
+                                        <?php $channels_associated_with_media = [];
+                                        $dom = new DOMDocument();
+
+                                        foreach ($media->getFeeds()->items as $channel) {
+                                            $a = $dom->createElement('a', htmlspecialchars($channel->title));
+                                            $a->setAttribute('href', htmlspecialchars(UNL_MediaHub::escape(UNL_MediaHub_Controller::getURL($channel))));
+                                            $channels_associated_with_media[] = $dom->saveHTML($a);
+                                        } ?>
+                                        <?php echo implode(", ", $channels_associated_with_media); ?>
+                                    </td>
+                                    <td class="dcf-txt-right" data-label="Actions">
+                                        <a href="<?php
+                                                    echo htmlspecialchars(UNL_MediaHub_Manager::getURL() . '?view=editcaptions&id=' . $media['id']);
+                                                    ?>" class="dcf-btn dcf-btn-primary dcf-mt-1">
+                                            <?php
+                                            ?>Manage Captions
+                                        </a>
+                                    </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php } else { ?>
+                    <p class="dcf-bold">There are currently no unreviewed AI-generated captions.</p>
+                <?php } ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/www/templates/html/Navigation.tpl.php
+++ b/www/templates/html/Navigation.tpl.php
@@ -8,6 +8,7 @@
     <li><a href="<?php echo $baseUrl ?>channels/">Channels</a></li>
     <li><a href="<?php echo $baseUrl ?>manager/">Manage Media</a></li>
     <?php if ($auth->isLoggedIn()) { ?>
+    <li><a href="<?php echo UNL_MediaHub_CaptionReviewListManager::getURL(); ?>">Unreviewed Media Captions</a></li>
         <?php if ($auth->getUser()->isAdmin()) { ?>
             <li><a href="<?php echo UNL_MediaHub_Controller::getURL(); ?>transcode-manager">Transcode Manager</a></li>
             <li><a href="<?php echo UNL_MediaHub_TranscriptionManager::getURL(); ?>">Transcription Manager</a></li>


### PR DESCRIPTION
Added a page for logged-in users to view a list of unreviewed AI-generated media captions along with related metadata. Implemented a warning banner to remind users to review their captions. Also made visual updates for media uploads and caption editing. Fixes #518.

- [x] Enabled AI-generated captions by default, unless the user explicitly opts out by unchecking the option (To maybe upload their own captions). Edited the description for the Opt In and Out of AI caption check box.
- [x] Added a page for logged-in users that lists media items with either active AI-generated captions that have not been reviewed, captions pending review for activation, and other relevant media metadata.
- [x] Displayed a warning banner on every page alerting users that they have unreviewed captions.
- [x] Updated the edit captions page to include a disabled radio button, allowing users to see which AI-generated caption is active—even if it hasn’t been reviewed—since automatic activation is now allowed.

Before this gets merged, I want to double-check on how we want to go about making sure the correct permissions apply to each video on the list. Added a permission check within the query, if that works, or if there is another way we want to go about it.
